### PR TITLE
feat: Initialize Visual Builder Shell

### DIFF
--- a/formsync/apps/formgen-api/tsconfig.json
+++ b/formsync/apps/formgen-api/tsconfig.json
@@ -18,5 +18,12 @@
         "strictBindCallApply": false,
         "forceConsistentCasingInFileNames": false,
         "noFallthroughCasesInSwitch": false
-    }
+    },
+    "include": [
+        "src/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
 }

--- a/formsync/apps/formgen-ui/src/App.tsx
+++ b/formsync/apps/formgen-ui/src/App.tsx
@@ -1,11 +1,46 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { BuilderProvider, useBuilder } from './context/BuilderContext';
+import { BuilderLayout } from './components/BuilderLayout';
+import './index.css';
+
+// Mock Data Loader to simulate "Load from API"
+const DataLoader: React.FC = () => {
+    const { dispatch } = useBuilder();
+
+    useEffect(() => {
+        // Simulating async load
+        setTimeout(() => {
+            dispatch({
+                type: 'UPDATE_FORM',
+                payload: {
+                    id: 'sample-form',
+                    name: 'Employee Onboarding',
+                    version: '1.0',
+                    meta: {
+                        title: 'Employee Onboarding Form',
+                        description: 'Please fill out your details below.'
+                    },
+                    theme: { primaryColor: '#3b82f6', fontFamily: 'Inter', radius: 6 },
+                    layout: { order: ['f1', 'f2', 'f3'] },
+                    fields: [
+                        { id: 'f1', key: 'fullName', type: 'text', label: 'Full Name', required: true },
+                        { id: 'f2', key: 'email', type: 'email', label: 'Email Address', required: true },
+                        { id: 'f3', key: 'role', type: 'select', label: 'Role', required: false, constraints: { enum: ['Dev', 'Design', 'Product'] } }
+                    ]
+                }
+            });
+        }, 500);
+    }, [dispatch]);
+
+    return null; // Headless component
+};
 
 function App() {
     return (
-        <div>
-            <h1>FormSync Form Generator</h1>
-            <p>Visual Form Builder Plugin System (Initial Setup)</p>
-        </div>
+        <BuilderProvider>
+            <DataLoader />
+            <BuilderLayout />
+        </BuilderProvider>
     );
 }
 

--- a/formsync/apps/formgen-ui/src/components/BuilderLayout.tsx
+++ b/formsync/apps/formgen-ui/src/components/BuilderLayout.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { LeftPanel } from './LeftPanel';
+import { Canvas } from './Canvas';
+import { RightPanel } from './RightPanel';
+
+export const BuilderLayout: React.FC = () => {
+    return (
+        <div className="builder-layout">
+            <LeftPanel />
+            <Canvas />
+            <RightPanel />
+        </div>
+    );
+};

--- a/formsync/apps/formgen-ui/src/components/Canvas.tsx
+++ b/formsync/apps/formgen-ui/src/components/Canvas.tsx
@@ -24,7 +24,7 @@ export const Canvas: React.FC = () => {
                     <div
                         key={field.id}
                         className={`field-item ${selectedFieldId === field.id ? 'selected' : ''}`}
-                        style={{ marginBottom: '1.5rem', cursor: 'default' }}
+                        style={{ marginBottom: '1.5rem', cursor: 'pointer' }}
                         onClick={(e) => {
                             e.stopPropagation();
                             dispatch({ type: 'SELECT_FIELD', payload: field.id });
@@ -34,8 +34,16 @@ export const Canvas: React.FC = () => {
                             {field.label} {field.required && <span style={{ color: 'red' }}>*</span>}
                         </label>
 
-                        {/* Placeholder Input Render */}
-                        <div className="field-input-mock" />
+                        {/* Enhanced Placeholder Input Render */}
+                        <div className="field-input-mock" style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            padding: '0 0.5rem',
+                            color: field.ui?.placeholder ? '#999' : 'transparent',
+                            fontStyle: 'italic'
+                        }}>
+                            {field.ui?.placeholder || 'Input...'}
+                        </div>
 
                         {field.ui?.helpText && (
                             <small className="text-muted" style={{ display: 'block', marginTop: '0.25rem' }}>

--- a/formsync/apps/formgen-ui/src/components/Canvas.tsx
+++ b/formsync/apps/formgen-ui/src/components/Canvas.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { useBuilder } from '../context/BuilderContext';
+
+export const Canvas: React.FC = () => {
+    const { state, dispatch } = useBuilder();
+    const { form, selectedFieldId } = state;
+
+    // Derive ordered fields
+    const orderedFields = form.layout.order
+        .map(id => form.fields.find(f => f.id === id))
+        .filter(f => !!f);
+
+    return (
+        <div className="canvas-area">
+            <div className="form-preview">
+                <h1 className="form-title">{form.meta?.title || form.name}</h1>
+                {form.meta?.description && (
+                    <p className="text-muted" style={{ marginBottom: '2rem' }}>
+                        {form.meta.description}
+                    </p>
+                )}
+
+                {orderedFields.map((field) => (
+                    <div
+                        key={field.id}
+                        className={`field-item ${selectedFieldId === field.id ? 'selected' : ''}`}
+                        style={{ marginBottom: '1.5rem', cursor: 'default' }}
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            dispatch({ type: 'SELECT_FIELD', payload: field.id });
+                        }}
+                    >
+                        <label className="field-label" style={{ marginBottom: '0.5rem' }}>
+                            {field.label} {field.required && <span style={{ color: 'red' }}>*</span>}
+                        </label>
+
+                        {/* Placeholder Input Render */}
+                        <div className="field-input-mock" />
+
+                        {field.ui?.helpText && (
+                            <small className="text-muted" style={{ display: 'block', marginTop: '0.25rem' }}>
+                                {field.ui.helpText}
+                            </small>
+                        )}
+                    </div>
+                ))}
+
+                {orderedFields.length === 0 && (
+                    <div className="text-muted" style={{ textAlign: 'center', padding: '4rem', border: '2px dashed #eee' }}>
+                        Form is empty.
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/formsync/apps/formgen-ui/src/components/LeftPanel.tsx
+++ b/formsync/apps/formgen-ui/src/components/LeftPanel.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useBuilder } from '../context/BuilderContext';
+import { FieldModel } from '@formsync/formgen-core';
+
+export const LeftPanel: React.FC = () => {
+    const { state, dispatch } = useBuilder();
+
+    // Sort fields based on layout order (if present)
+    const orderedFields = state.form.layout.order
+        .map((id) => state.form.fields.find((f) => f.id === id))
+        .filter((f): f is FieldModel => !!f);
+
+    // Also include any fields not in layout order (fallback)
+    const unlistedFields = state.form.fields.filter(
+        f => !state.form.layout.order.includes(f.id)
+    );
+
+    const displayFields = [...orderedFields, ...unlistedFields];
+
+    return (
+        <div className="panel">
+            <div className="panel-header">Field Explorer</div>
+            <div className="panel-content">
+                <div className="text-muted" style={{ marginBottom: '1rem' }}>
+                    {displayFields.length} Fields Defined
+                </div>
+
+                {displayFields.map((field) => (
+                    <div
+                        key={field.id}
+                        className={`field-item ${state.selectedFieldId === field.id ? 'selected' : ''}`}
+                        onClick={() => dispatch({ type: 'SELECT_FIELD', payload: field.id })}
+                    >
+                        <div className="field-label">{field.label}</div>
+                        <div className="text-muted" style={{ fontSize: '0.75rem' }}>
+                            Type: {field.type} | Key: {field.key}
+                        </div>
+                    </div>
+                ))}
+
+                {displayFields.length === 0 && (
+                    <div className="text-muted" style={{ textAlign: 'center', marginTop: '2rem' }}>
+                        No fields found in model.
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/formsync/apps/formgen-ui/src/components/RightPanel.tsx
+++ b/formsync/apps/formgen-ui/src/components/RightPanel.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useBuilder } from '../context/BuilderContext';
+
+export const RightPanel: React.FC = () => {
+    const { state } = useBuilder();
+    const selectedField = state.form.fields.find((f) => f.id === state.selectedFieldId);
+
+    if (!selectedField) {
+        return (
+            <div className="panel">
+                <div className="panel-header">Properties</div>
+                <div className="panel-content" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <span className="text-muted">Select a field to view properties</span>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="panel">
+            <div className="panel-header">Properties: {selectedField.key}</div>
+            <div className="panel-content">
+                <div style={{ marginBottom: '1rem' }}>
+                    <label className="field-label">Label</label>
+                    <div className="field-input-mock" style={{ padding: '0.5rem' }}>
+                        {selectedField.label}
+                    </div>
+                </div>
+
+                <div style={{ marginBottom: '1rem' }}>
+                    <label className="field-label">Type</label>
+                    <div className="field-input-mock" style={{ padding: '0.5rem' }}>
+                        {selectedField.type}
+                    </div>
+                </div>
+
+                <div style={{ marginBottom: '1rem' }}>
+                    <label className="field-label">Constraints</label>
+                    <pre className="code-block">
+                        {JSON.stringify(selectedField.constraints, null, 2) || 'None'}
+                    </pre>
+                </div>
+
+                <div style={{ marginTop: '2rem', borderTop: '1px solid #eee', paddingTop: '1rem' }}>
+                    <small className="text-muted">Debug ID: {selectedField.id}</small>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/formsync/apps/formgen-ui/src/components/RightPanel.tsx
+++ b/formsync/apps/formgen-ui/src/components/RightPanel.tsx
@@ -1,9 +1,25 @@
 import React from 'react';
 import { useBuilder } from '../context/BuilderContext';
+import { FieldModel } from '@formsync/formgen-core';
 
 export const RightPanel: React.FC = () => {
-    const { state } = useBuilder();
+    const { state, dispatch } = useBuilder();
     const selectedField = state.form.fields.find((f) => f.id === state.selectedFieldId);
+
+    const handleUpdate = (updates: Partial<FieldModel>) => {
+        if (!selectedField) return;
+        dispatch({
+            type: 'UPDATE_FIELD',
+            payload: { fieldId: selectedField.id, updates },
+        });
+    };
+
+    const handleUiUpdate = (key: string, value: any) => {
+        if (!selectedField) return;
+        handleUpdate({
+            ui: { ...selectedField.ui, [key]: value },
+        });
+    };
 
     if (!selectedField) {
         return (
@@ -20,25 +36,60 @@ export const RightPanel: React.FC = () => {
         <div className="panel">
             <div className="panel-header">Properties: {selectedField.key}</div>
             <div className="panel-content">
+                {/* Label */}
                 <div style={{ marginBottom: '1rem' }}>
                     <label className="field-label">Label</label>
-                    <div className="field-input-mock" style={{ padding: '0.5rem' }}>
-                        {selectedField.label}
-                    </div>
+                    <input
+                        className="field-input-mock"
+                        style={{ pointerEvents: 'auto' }}
+                        value={selectedField.label}
+                        onChange={(e) => handleUpdate({ label: e.target.value })}
+                    />
                 </div>
 
+                {/* Type (Read-only for now) */}
                 <div style={{ marginBottom: '1rem' }}>
                     <label className="field-label">Type</label>
-                    <div className="field-input-mock" style={{ padding: '0.5rem' }}>
+                    <div className="field-input-mock" style={{ padding: '0.5rem', background: '#f5f5f5' }}>
                         {selectedField.type}
                     </div>
                 </div>
 
+                {/* Required */}
                 <div style={{ marginBottom: '1rem' }}>
-                    <label className="field-label">Constraints</label>
-                    <pre className="code-block">
-                        {JSON.stringify(selectedField.constraints, null, 2) || 'None'}
-                    </pre>
+                    <label style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}>
+                        <input
+                            type="checkbox"
+                            checked={selectedField.required}
+                            onChange={(e) => handleUpdate({ required: e.target.checked })}
+                            style={{ marginRight: '0.5rem' }}
+                        />
+                        Required Field
+                    </label>
+                </div>
+
+                {/* Placeholder */}
+                <div style={{ marginBottom: '1rem' }}>
+                    <label className="field-label">Placeholder</label>
+                    <input
+                        className="field-input-mock"
+                        style={{ pointerEvents: 'auto' }}
+                        value={selectedField.ui?.placeholder || ''}
+                        onChange={(e) => handleUiUpdate('placeholder', e.target.value)}
+                        placeholder="e.g. Enter your name..."
+                    />
+                </div>
+
+                {/* Help Text */}
+                <div style={{ marginBottom: '1rem' }}>
+                    <label className="field-label">Help Text</label>
+                    <textarea
+                        className="field-input-mock"
+                        style={{ pointerEvents: 'auto', height: '60px', padding: '0.5rem', resize: 'vertical' }}
+                        value={selectedField.ui?.helpText || ''}
+                        onChange={(e) => handleUiUpdate('helpText', e.target.value)}
+                        placeholder="Description below the field..."
+                    />
                 </div>
 
                 <div style={{ marginTop: '2rem', borderTop: '1px solid #eee', paddingTop: '1rem' }}>

--- a/formsync/apps/formgen-ui/src/context/BuilderContext.tsx
+++ b/formsync/apps/formgen-ui/src/context/BuilderContext.tsx
@@ -1,0 +1,57 @@
+import React, { createContext, useContext, useReducer, Dispatch } from 'react';
+import { FormModel } from '@formsync/formgen-core';
+
+// --- State Definition ---
+interface BuilderState {
+    form: FormModel;
+    selectedFieldId: string | null;
+}
+
+// --- Action Definitions ---
+type BuilderAction =
+    | { type: 'SELECT_FIELD'; payload: string | null }
+    | { type: 'UPDATE_FORM'; payload: FormModel };
+
+// --- Initial State ---
+// Minimal default state to avoid crashes before data is loaded
+const initialState: BuilderState = {
+    form: {
+        id: 'default',
+        name: 'Loading...',
+        version: '1.0.0',
+        theme: { primaryColor: '#000', fontFamily: 'sans-serif', radius: 4 },
+        layout: { order: [] },
+        fields: [],
+    },
+    selectedFieldId: null,
+};
+
+// --- Reducer ---
+function builderReducer(state: BuilderState, action: BuilderAction): BuilderState {
+    switch (action.type) {
+        case 'SELECT_FIELD':
+            return { ...state, selectedFieldId: action.payload };
+        case 'UPDATE_FORM':
+            return { ...state, form: action.payload };
+        default:
+            return state;
+    }
+}
+
+// --- Context Setup ---
+const BuilderContext = createContext<{
+    state: BuilderState;
+    dispatch: Dispatch<BuilderAction>;
+}>({ state: initialState, dispatch: () => null });
+
+export const BuilderProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [state, dispatch] = useReducer(builderReducer, initialState);
+
+    return (
+        <BuilderContext.Provider value={{ state, dispatch }}>
+            {children}
+        </BuilderContext.Provider>
+    );
+};
+
+export const useBuilder = () => useContext(BuilderContext);

--- a/formsync/apps/formgen-ui/src/context/BuilderContext.tsx
+++ b/formsync/apps/formgen-ui/src/context/BuilderContext.tsx
@@ -10,7 +10,8 @@ interface BuilderState {
 // --- Action Definitions ---
 type BuilderAction =
     | { type: 'SELECT_FIELD'; payload: string | null }
-    | { type: 'UPDATE_FORM'; payload: FormModel };
+    | { type: 'UPDATE_FORM'; payload: FormModel }
+    | { type: 'UPDATE_FIELD'; payload: { fieldId: string; updates: Partial<FormModel['fields'][0]> } };
 
 // --- Initial State ---
 // Minimal default state to avoid crashes before data is loaded
@@ -33,6 +34,18 @@ function builderReducer(state: BuilderState, action: BuilderAction): BuilderStat
             return { ...state, selectedFieldId: action.payload };
         case 'UPDATE_FORM':
             return { ...state, form: action.payload };
+        case 'UPDATE_FIELD':
+            return {
+                ...state,
+                form: {
+                    ...state.form,
+                    fields: state.form.fields.map((field) =>
+                        field.id === action.payload.fieldId
+                            ? { ...field, ...action.payload.updates }
+                            : field
+                    ),
+                },
+            };
         default:
             return state;
     }

--- a/formsync/apps/formgen-ui/src/index.css
+++ b/formsync/apps/formgen-ui/src/index.css
@@ -1,0 +1,122 @@
+:root {
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background-color: #f5f5f5;
+  color: #333;
+}
+
+/* --- Builder Layout Grid --- */
+.builder-layout {
+  display: grid;
+  grid-template-columns: 250px 1fr 300px; /* Left | Canvas | Right */
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* --- Panels --- */
+.panel {
+  background: white;
+  border-right: 1px solid #e0e0e0;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.panel-header {
+  padding: 1rem;
+  border-bottom: 1px solid #eee;
+  font-weight: 600;
+  font-size: 0.9rem;
+  background: #fafafa;
+}
+
+.panel-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+/* --- Canvas Area --- */
+.canvas-area {
+  background: #f0f2f5;
+  padding: 2rem;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  overflow-y: auto;
+}
+
+.form-preview {
+  background: white;
+  width: 100%;
+  max-width: 600px;
+  min-height: 80vh;
+  padding: 2rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+}
+
+.form-title {
+  margin-top: 0;
+  margin-bottom: 2rem;
+  font-size: 1.5rem;
+  border-bottom: 2px solid #eee;
+  padding-bottom: 0.5rem;
+}
+
+/* --- Field Items --- */
+.field-item {
+  padding: 0.75rem;
+  margin-bottom: 0.5rem;
+  background: #f8f9fa;
+  border: 1px solid #eee;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.field-item:hover {
+  border-color: #ccc;
+  background: #f0f0f0;
+}
+
+.field-item.selected {
+  border-color: #3b82f6;
+  background: #eff6ff;
+  box-shadow: 0 0 0 1px #3b82f6;
+}
+
+.field-label {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+}
+
+.field-input-mock {
+  width: 100%;
+  height: 36px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: white;
+  pointer-events: none; /* Preview only */
+}
+
+/* --- Utilities --- */
+.text-muted { color: #666; font-size: 0.85rem; }
+.code-block {
+    background: #2d2d2d;
+    color: #eee;
+    padding: 0.5rem;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    overflow-x: auto;
+    margin-top: 1rem;
+}

--- a/formsync/package.json
+++ b/formsync/package.json
@@ -8,9 +8,13 @@
     "packages/*"
   ],
   "scripts": {
-    "dev:api": "npm run dev --workspace=schema-api",
-    "dev:ui": "npm run dev --workspace=schema-ui",
-    "dev": "concurrently \"npm run dev:api\" \"npm run dev:ui\"",
+    "dev:schema:api": "npm run dev --workspace=schema-api",
+    "dev:schema:ui": "npm run dev --workspace=schema-ui",
+    "dev:schema": "concurrently \"npm run dev:schema:api\" \"npm run dev:schema:ui\"",
+    "dev:formgen:api": "npm run start:dev --workspace=formgen-api",
+    "dev:formgen:ui": "npm run dev --workspace=formgen-ui",
+    "dev:formgen": "concurrently \"npm run dev:formgen:api\" \"npm run dev:formgen:ui\"",
+    "dev": "concurrently \"npm run dev:schema\" \"npm run dev:formgen\"",
     "build": "npm run build --workspaces",
     "test": "npm run test --workspaces",
     "lint": "eslint . --ext .ts,.tsx",


### PR DESCRIPTION
This PR completes #26  Visual Builder Shell by introducing the foundational UI structure for the schema-driven frontend form builder.

The goal of this change is to establish a clean, extensible UI skeleton that consumes the internal FormModel, while deliberately avoiding premature complexity (drag-and-drop, plugins, export logic).


What Was Implemented

1. Visual Builder Layout
	•	Implemented a 3-panel UI shell using CSS Grid:
	•	Left Panel – Field list (read-only)
	•	Center Panel – Live preview canvas
	•	Right Panel – Properties panel (selected field details)

2. Global State Management
	•	Introduced a lightweight global state using React Context + useReducer:
	•	form: FormModel
	•	selectedFieldId: string | null
	•	Avoids prop drilling and external state libraries
	•	Keeps UI state aligned with the internal data model

3. FormModel Integration
	•	UI consumes the shared FormModel from @formsync/formgen-core
	•	Field rendering and layout are driven by form.fields and form.layout
	•	Selection state is reflected consistently across panels

4. Clean Component Separation
	•	BuilderLayout – layout container
	•	LeftPanel – field explorer
	•	Canvas – preview area
	•	RightPanel – properties display

Each component has a single responsibility and minimal coupling.


Architectural Notes
	•	No JSON Schema parsing logic exists in the UI
	•	No plugin rendering or export logic implemented yet
	•	No external UI libraries used (CSS Grid only)
	•	Structure is intentionally minimal to support future:
	•	drag-and-drop
	•	plugin-based rendering
	•	styling customization
	•	export integration

