### PR TITLE
Update architecture diagram image path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ FormSync transforms the way developers and non-technical users create and manage
 
 ## 🏗️ Architecture
 
-![FormSync System Architecture](./docs/architecture.png)
+![FormSync System Architecture](./formsync/docs/architecture.png)
 
 FormSync consists of four main components working together:
 


### PR DESCRIPTION
Changed the image path for the FormSync system architecture diagram to reflect its new location under formsync/docs.