### PR TITLE
Hansi/feature/generated form accessibility

### DIFF
--- a/formsync/frontend/src/builder/RightPanel.tsx
+++ b/formsync/frontend/src/builder/RightPanel.tsx
@@ -290,7 +290,7 @@ export const RightPanel: React.FC<RightPanelProps> = ({
                     </label>
                 </div>
                 <Group label="Placeholder">
-                    <input className="control-input" value={selectedField.ui?.placeholder ?? ''} onChange={(e) => handleUiUpdate('placeholder', e.target.value)} placeholder="Enter placeholder…" />
+                    <input className="control-input" value={selectedField.ui?.placeholder ?? ''} onChange={(e) => handleUiUpdate('placeholder', e.target.value)} placeholder={`Enter ${selectedField.label.toLowerCase()}…`} />
                 </Group>
                 <Group label="Help Text">
                     <textarea className="control-input" style={{ height: '56px', resize: 'vertical', paddingTop: '0.5rem' }} value={selectedField.ui?.helpText ?? ''} onChange={(e) => handleUiUpdate('helpText', e.target.value)} placeholder="Describe this field…" />

--- a/formsync/frontend/src/context/BuilderContext.tsx
+++ b/formsync/frontend/src/context/BuilderContext.tsx
@@ -283,13 +283,16 @@ export const useBuilder = () => useContext(BuilderContext);
 /** Creates a new FieldModel with sensible defaults for a given type */
 export function createField(type: FieldType, stepIndex?: number): FieldModel {
     const id = `field-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+    const baseLabel = labelForType(type);
     const base: FieldModel = {
         id,
         key: id,
         type,
-        label: labelForType(type),
+        label: baseLabel,
         required: false,
-        ui: {},
+        ui: {
+            placeholder: `Enter ${baseLabel.toLowerCase()}...`
+        },
         ...(stepIndex !== undefined ? { stepIndex } : {}),
     };
 

--- a/formsync/services/formgen-service/src/generators/react-generator.ts
+++ b/formsync/services/formgen-service/src/generators/react-generator.ts
@@ -78,13 +78,25 @@ export function generateAppTsx(formModel: FormModel): string {
     formBody = `<div className="empty-state">Form is empty.</div>`;
   }
 
-  return `import React, { FormEvent } from 'react';
+  return `import React, { FormEvent, useState } from 'react';
 
 function App() {
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const validate = (data: Record<string, FormDataEntryValue>): Record<string, string> => {
+    const errs: Record<string, string> = {};
+    // Add field-level validation here — key matches the field 'name' attribute.
+    // Example: if (!data['email']) errs['email'] = 'Email is required.';
+    return errs;
+  };
+
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
     const data = Object.fromEntries(formData.entries());
+    const errs = validate(data);
+    setErrors(errs);
+    if (Object.keys(errs).length > 0) return;
     console.log('Form submitted:', data);
     // Add your form submission logic here
   };
@@ -164,45 +176,115 @@ function generateFieldComponent(field: FieldModel, theme: any): string {
 
   // ── input element ──────────────────────────────────────────────────────────
   let inputElement: string;
+  // Build aria attributes shared across input types
+  // - aria-required: explicitly declares the field as required for AT
+  // - aria-describedby: links to help text and/or error message spans
+  // - aria-invalid: evaluated at runtime via {errors['key'] ? 'true' : 'false'}
+  // - aria-errormessage: points to the error span when invalid
+  const describedByParts: string[] = [];
+  if (helpText) describedByParts.push(`${id}-help`);
+  describedByParts.push(`${id}-error`);
+  const ariaDescribedBy = `aria-describedby="${describedByParts.join(' ')}"`;
+  const ariaRequired = required ? `aria-required="true"` : '';
+  const ariaInvalid = `aria-invalid={errors['${key}'] ? 'true' : 'false'}`;
+  const ariaErrMsg = `aria-errormessage="${id}-error"`;
+
   switch (type) {
     case 'textarea':
-      inputElement = `<textarea name="${key}" id="${id}" className="field-input" placeholder="${escapeHtml(placeholder)}" ${required ? 'required' : ''}></textarea>`;
+      inputElement = `<textarea
+            name="${key}"
+            id="${id}"
+            className="field-input"
+            placeholder="${escapeHtml(placeholder)}"
+            ${required ? 'required' : ''}
+            ${ariaRequired}
+            ${ariaInvalid}
+            ${ariaErrMsg}
+            ${ariaDescribedBy}
+          ></textarea>`;
       break;
     case 'select': {
       const options = field.constraints?.enum || [];
-      inputElement = `<select name="${key}" id="${id}" className="field-input" ${required ? 'required' : ''}>
+      inputElement = `<select
+            name="${key}"
+            id="${id}"
+            className="field-input"
+            ${required ? 'required' : ''}
+            ${ariaRequired}
+            ${ariaInvalid}
+            ${ariaErrMsg}
+            ${ariaDescribedBy}
+          >
             <option value="">${escapeHtml(placeholder) || 'Select...'}</option>
             ${options.map(o => `<option value="${escapeHtml(o)}">${escapeHtml(o)}</option>`).join('\n            ')}
           </select>`;
       break;
     }
     case 'checkbox':
-      inputElement = `<input type="checkbox" name="${key}" id="${id}" className="field-input" />`;
+      // Checkboxes use aria-checked semantics; aria-required still applies
+      inputElement = `<input
+            type="checkbox"
+            name="${key}"
+            id="${id}"
+            className="field-input"
+            ${ariaRequired}
+            ${ariaInvalid}
+            ${ariaErrMsg}
+            ${ariaDescribedBy}
+          />`;
       break;
     default:
       // text, email, password, number, date
-      inputElement = `<input type="${type}" name="${key}" id="${id}" className="field-input" placeholder="${escapeHtml(placeholder)}" ${required ? 'required' : ''} />`;
+      inputElement = `<input
+            type="${type}"
+            name="${key}"
+            id="${id}"
+            className="field-input"
+            placeholder="${escapeHtml(placeholder)}"
+            ${required ? 'required' : ''}
+            ${ariaRequired}
+            ${ariaInvalid}
+            ${ariaErrMsg}
+            ${ariaDescribedBy}
+          />`;
   }
 
-  // ── checkbox wrapper ───────────────────────────────────────────────────────
+  // ── checkbox wrapper ─────────────────────────────────────────────────────
+  // Checkboxes render the label after the input; error lives below the group
   if (type === 'checkbox') {
-    const checkboxExtra = [`display: 'flex'`, `alignItems: 'center'`];
+    const checkboxExtra = [`display: 'flex'`, `alignItems: 'center'`, `flexWrap: 'wrap'`];
     return `<div className="field-item checkbox-item" ${buildStyle(checkboxExtra)}>
           ${inputElement}
           <label htmlFor="${id}" className="field-label" style={{ marginBottom: 0 }}>
-            ${escapeHtml(label)}${required ? '<span className="required">*</span>' : ''}
+            ${escapeHtml(label)}${required ? '<span className="required" aria-hidden="true">*</span>' : ''}
           </label>
-          ${helpText ? `<small className="field-help-text" style={{ marginLeft: 'auto' }}>${escapeHtml(helpText)}</small>` : ''}
+          ${helpText ? `<small id="${id}-help" className="field-help-text" style={{ marginLeft: 'auto' }}>${escapeHtml(helpText)}</small>` : ''}
+          <span
+            id="${id}-error"
+            className="field-error"
+            role="alert"
+            aria-live="polite"
+          >
+            {errors['${key}']}
+          </span>
         </div>`;
   }
 
-  // ── standard field wrapper ─────────────────────────────────────────────────
+  // ── standard field wrapper ───────────────────────────────────────────────
   return `<div className="field-item" ${buildStyle()}>
           <label htmlFor="${id}" className="field-label">
-            ${escapeHtml(label)}${required ? '<span className="required">*</span>' : ''}
+            ${escapeHtml(label)}${required ? '<span className="required" aria-hidden="true">*</span>' : ''}
           </label>
           ${inputElement}
-          ${helpText ? `<small className="field-help-text">${escapeHtml(helpText)}</small>` : ''}
+          ${helpText ? `<small id="${id}-help" className="field-help-text">${escapeHtml(helpText)}</small>` : ''}
+          <span
+            id="${id}-error"
+            className="field-error"
+            role="alert"
+            aria-live="polite"
+          >
+            {errors['${key}']}
+          </span>
         </div>`;
 }
 

--- a/formsync/services/formgen-service/src/generators/react-generator.ts
+++ b/formsync/services/formgen-service/src/generators/react-generator.ts
@@ -78,7 +78,20 @@ export function generateAppTsx(formModel: FormModel): string {
     formBody = `<div className="empty-state">Form is empty.</div>`;
   }
 
+  // Build a static key → DOM-id map so the generated form can auto-focus
+  // the first invalid field without needing React refs.
+  const allFields = collectAllFields(orderedFields);
+  const fieldIdMapEntries = allFields
+    .map((f: FieldModel) => `  '${f.key}': '${f.id}'`)
+    .join(',\n');
+
   return `import React, { FormEvent, useState } from 'react';
+
+// Maps every field's form key to its DOM id.
+// Generated at build time — do not edit manually.
+const FIELD_ID_MAP: Record<string, string> = {
+${fieldIdMapEntries}
+};
 
 function App() {
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -96,7 +109,15 @@ function App() {
     const data = Object.fromEntries(formData.entries());
     const errs = validate(data);
     setErrors(errs);
-    if (Object.keys(errs).length > 0) return;
+    if (Object.keys(errs).length > 0) {
+      // Move focus to the first invalid field so keyboard/AT users are guided.
+      const firstErrorKey = Object.keys(errs)[0];
+      const firstErrorId = FIELD_ID_MAP[firstErrorKey];
+      if (firstErrorId) {
+        (document.getElementById(firstErrorId) as HTMLElement | null)?.focus();
+      }
+      return;
+    }
     console.log('Form submitted:', data);
     // Add your form submission logic here
   };
@@ -286,6 +307,22 @@ function generateFieldComponent(field: FieldModel, theme: any): string {
             {errors['${key}']}
           </span>
         </div>`;
+}
+
+/**
+ * Recursively collect every leaf field (including group children) so we can
+ * build a complete key → id mapping used by FIELD_ID_MAP in the App component.
+ */
+function collectAllFields(fields: FieldModel[]): FieldModel[] {
+  const result: FieldModel[] = [];
+  for (const f of fields) {
+    if (f.type === 'group' && f.children && f.children.length > 0) {
+      result.push(...collectAllFields(f.children));
+    } else {
+      result.push(f);
+    }
+  }
+  return result;
 }
 
 /**

--- a/formsync/services/formgen-service/src/generators/react-generator.ts
+++ b/formsync/services/formgen-service/src/generators/react-generator.ts
@@ -184,7 +184,9 @@ const AUTO_COMPLETE_MAP: Record<string, string> = {
 function generateFieldComponent(field: FieldModel, theme: any): string {
   const { id, key, type, label, required, ui } = field;
   // date/number inputs don't benefit from placeholder — omit it to keep markup clean.
-  const placeholder = (type === 'date' || type === 'number') ? '' : (ui?.placeholder || '');
+  const explicitPlaceholder = ui?.placeholder;
+  const computedPlaceholder = explicitPlaceholder ?? `Enter ${label.toLowerCase()}...`;
+  const placeholder = type === 'date' ? '' : computedPlaceholder;
   const helpText = ui?.helpText;
   const overrides = ui?.styleOverrides as Record<string, string> | undefined;
   // Look up autoComplete token for this field key (WCAG 1.3.5).

--- a/formsync/services/formgen-service/src/generators/react-generator.ts
+++ b/formsync/services/formgen-service/src/generators/react-generator.ts
@@ -47,7 +47,7 @@ export function generateAppTsx(formModel: FormModel): string {
         </section>`;
     }).join('\n\n        ');
 
-    formBody = `<form onSubmit={handleSubmit}>
+    formBody = `<form onSubmit={handleSubmit} noValidate>
         ${sections}
 
         <button
@@ -63,7 +63,7 @@ export function generateAppTsx(formModel: FormModel): string {
     const fieldComponents = orderedFields
       .map(f => generateFieldComponent(f, theme))
       .join('\n\n');
-    formBody = `<form onSubmit={handleSubmit}>
+    formBody = `<form onSubmit={handleSubmit} noValidate>
         ${fieldComponents}
 
         <button
@@ -95,6 +95,8 @@ ${fieldIdMapEntries}
 
 function App() {
   const [errors, setErrors] = useState<Record<string, string>>({});
+  // Drives the aria-live announcement region — screen readers read this after submit.
+  const [statusMessage, setStatusMessage] = useState<string>('');
 
   const validate = (data: Record<string, FormDataEntryValue>): Record<string, string> => {
     const errs: Record<string, string> = {};
@@ -109,21 +111,42 @@ function App() {
     const data = Object.fromEntries(formData.entries());
     const errs = validate(data);
     setErrors(errs);
-    if (Object.keys(errs).length > 0) {
-      // Move focus to the first invalid field so keyboard/AT users are guided.
+    const errorCount = Object.keys(errs).length;
+    if (errorCount > 0) {
+      // Announce a summary to screen readers via the polite live region.
+      setStatusMessage(
+        errorCount === 1
+          ? '1 error found. Please review the highlighted field.'
+          : errorCount + ' errors found. Please review the highlighted fields.'
+      );
+      // Move focus AND scroll to the first invalid field.
       const firstErrorKey = Object.keys(errs)[0];
       const firstErrorId = FIELD_ID_MAP[firstErrorKey];
       if (firstErrorId) {
-        (document.getElementById(firstErrorId) as HTMLElement | null)?.focus();
+        const el = document.getElementById(firstErrorId) as HTMLElement | null;
+        el?.focus();
+        el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }
       return;
     }
+    // Clear any prior status message on a clean submission.
+    setStatusMessage('');
     console.log('Form submitted:', data);
     // Add your form submission logic here
   };
 
   return (
     <div className="form-container">
+      {/* Visually hidden — screen readers announce statusMessage when it changes. */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {statusMessage}
+      </div>
+
       <h1 className="form-title">${escapeHtml(title)}</h1>
       ${description ? `<p className="form-description">${escapeHtml(description)}</p>` : ''}
 
@@ -147,11 +170,25 @@ export default App;
  *    to avoid the invalid-JSX duplicate-style-attribute pitfall.
  *  - Only non-empty override values emit a CSS var entry (no empty strings polluting styles).
  */
+/** WCAG 1.3.5 — maps field keys to HTML autocomplete tokens so password
+ *  managers and assistive technology can identify the purpose of each input. */
+const AUTO_COMPLETE_MAP: Record<string, string> = {
+  name: 'name', firstName: 'given-name', lastName: 'family-name',
+  email: 'email', phone: 'tel', mobile: 'tel',
+  password: 'current-password', newPassword: 'new-password',
+  street: 'street-address', city: 'address-level2', state: 'address-level1',
+  zip: 'postal-code', country: 'country-name',
+  organisation: 'organization', company: 'organization',
+};
+
 function generateFieldComponent(field: FieldModel, theme: any): string {
   const { id, key, type, label, required, ui } = field;
-  const placeholder = ui?.placeholder || '';
+  // date/number inputs don't benefit from placeholder — omit it to keep markup clean.
+  const placeholder = (type === 'date' || type === 'number') ? '' : (ui?.placeholder || '');
   const helpText = ui?.helpText;
   const overrides = ui?.styleOverrides as Record<string, string> | undefined;
+  // Look up autoComplete token for this field key (WCAG 1.3.5).
+  const autoComplete = AUTO_COMPLETE_MAP[key] ?? '';
 
   // Collect per-field CSS custom property entries (only truthy values)
   const overrideVars: string[] = overrides
@@ -210,18 +247,21 @@ function generateFieldComponent(field: FieldModel, theme: any): string {
   const ariaInvalid = `aria-invalid={errors['${key}'] ? 'true' : 'false'}`;
   const ariaErrMsg = `aria-errormessage="${id}-error"`;
 
+  const autoCompleteAttr = autoComplete ? `autoComplete="${autoComplete}"` : '';
+
   switch (type) {
     case 'textarea':
       inputElement = `<textarea
             name="${key}"
             id="${id}"
             className="field-input"
-            placeholder="${escapeHtml(placeholder)}"
+            ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ''}
             ${required ? 'required' : ''}
             ${ariaRequired}
             ${ariaInvalid}
             ${ariaErrMsg}
             ${ariaDescribedBy}
+            ${autoCompleteAttr}
           ></textarea>`;
       break;
     case 'select': {
@@ -235,6 +275,7 @@ function generateFieldComponent(field: FieldModel, theme: any): string {
             ${ariaInvalid}
             ${ariaErrMsg}
             ${ariaDescribedBy}
+            ${autoCompleteAttr}
           >
             <option value="">${escapeHtml(placeholder) || 'Select...'}</option>
             ${options.map(o => `<option value="${escapeHtml(o)}">${escapeHtml(o)}</option>`).join('\n            ')}
@@ -242,7 +283,8 @@ function generateFieldComponent(field: FieldModel, theme: any): string {
       break;
     }
     case 'checkbox':
-      // Checkboxes use aria-checked semantics; aria-required still applies
+      // Checkboxes use aria-checked semantics; aria-required still applies.
+      // autoComplete is not applicable to checkboxes — omitted intentionally.
       inputElement = `<input
             type="checkbox"
             name="${key}"
@@ -261,12 +303,13 @@ function generateFieldComponent(field: FieldModel, theme: any): string {
             name="${key}"
             id="${id}"
             className="field-input"
-            placeholder="${escapeHtml(placeholder)}"
+            ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ''}
             ${required ? 'required' : ''}
             ${ariaRequired}
             ${ariaInvalid}
             ${ariaErrMsg}
             ${ariaDescribedBy}
+            ${autoCompleteAttr}
           />`;
   }
 

--- a/formsync/services/formgen-service/src/generators/templates.ts
+++ b/formsync/services/formgen-service/src/generators/templates.ts
@@ -240,6 +240,13 @@ body {
   transition: all 0.2s ease;
 }
 
+input[type="checkbox"].field-input {
+  width: auto;
+  margin-right: 0.5rem;
+  padding: 0;
+  cursor: pointer;
+}
+
 /* :focus-visible targets keyboard nav only — mouse users won't see the ring.
    We keep the outline visible for High Contrast / forced-colors mode (WCAG 2.4.11). */
 .field-input:focus {

--- a/formsync/services/formgen-service/src/generators/templates.ts
+++ b/formsync/services/formgen-service/src/generators/templates.ts
@@ -257,6 +257,27 @@ body {
   margin-top: 0.25rem;
 }
 
+/* Accessible error message — hidden when empty, visible when there is an error */
+.field-error {
+  display: block;
+  min-height: 1.25rem; /* reserve space so the layout doesn't jump */
+  font-size: 0.8rem;
+  color: var(--color-error);
+  margin-top: 0.2rem;
+}
+
+/* Visual treatment for invalid inputs — mirrors aria-invalid="true" */
+.field-input[aria-invalid="true"] {
+  border-color: var(--color-error);
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15);
+}
+
+.field-input[aria-invalid="true"]:focus {
+  outline: none;
+  border-color: var(--color-error);
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.25);
+}
+
 /* Submit Button */
 .submit-button {
   width: 100%;

--- a/formsync/services/formgen-service/src/generators/templates.ts
+++ b/formsync/services/formgen-service/src/generators/templates.ts
@@ -240,10 +240,16 @@ body {
   transition: all 0.2s ease;
 }
 
+/* :focus-visible targets keyboard nav only — mouse users won't see the ring.
+   We keep the outline visible for High Contrast / forced-colors mode (WCAG 2.4.11). */
 .field-input:focus {
-  outline: none;
+  outline: 2px solid transparent;
+}
+.field-input:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
   border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 20%, transparent);
 }
 
 .field-input::placeholder {
@@ -278,6 +284,35 @@ body {
   box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.25);
 }
 
+/* Screen-reader-only utility — visually hidden but fully accessible to AT.
+   Used by the aria-live status region. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Grouped fields — theme-aware fieldset */
+.field-group {
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.field-legend {
+  padding: 0 0.5rem;
+  font-weight: 600;
+  color: var(--color-text);
+  font-size: 0.95rem;
+}
+
 /* Submit Button */
 .submit-button {
   width: 100%;
@@ -299,6 +334,17 @@ body {
 
 .submit-button:active {
   opacity: 0.8;
+}
+
+/* Visible keyboard focus ring for the submit button (WCAG 2.4.11). */
+.submit-button:focus {
+  outline: 2px solid transparent;
+}
+
+.submit-button:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-primary) 25%, transparent);
 }
 
 /* Empty State */


### PR DESCRIPTION
This pull request introduces major accessibility improvements and usability enhancements to the React form generator. The changes focus on providing better support for screen readers, keyboard navigation, and error handling, while also improving placeholder consistency and visual feedback for invalid fields.

Accessibility and error handling improvements:

* Added runtime error tracking, screen-reader-friendly status messages, and auto-focus/scroll to the first invalid field in the generated form. This includes a visually hidden live region for status updates and per-field error messages rendered with proper ARIA attributes. (`formsync/services/formgen-service/src/generators/react-generator.ts` [[1]](diffhunk://#diff-72963a081da83546612b9b345dbf80cf726d64b98225b8935adeb30f0f7ed45dL81-R149) [[2]](diffhunk://#diff-72963a081da83546612b9b345dbf80cf726d64b98225b8935adeb30f0f7ed45dR239-R372)
* Enhanced input elements with ARIA attributes (`aria-required`, `aria-invalid`, `aria-errormessage`, `aria-describedby`) for all field types, and added WCAG-compliant autocomplete tokens for relevant fields. (`formsync/services/formgen-service/src/generators/react-generator.ts` [[1]](diffhunk://#diff-72963a081da83546612b9b345dbf80cf726d64b98225b8935adeb30f0f7ed45dR173-R193) [[2]](diffhunk://#diff-72963a081da83546612b9b345dbf80cf726d64b98225b8935adeb30f0f7ed45dR239-R372)
* Improved CSS for accessibility: added styles for visible focus rings (keyboard navigation), error highlighting, screen-reader-only elements, and reserved space for error messages to prevent layout jumps. (`formsync/services/formgen-service/src/generators/templates.ts` [[1]](diffhunk://#diff-fc05fbfe830620603a785a362e06a5afc6175321ecb8c1c628b4c83bc3461a1eR243-R259) [[2]](diffhunk://#diff-fc05fbfe830620603a785a362e06a5afc6175321ecb8c1c628b4c83bc3461a1eR273-R322) [[3]](diffhunk://#diff-fc05fbfe830620603a785a362e06a5afc6175321ecb8c1c628b4c83bc3461a1eR346-R356)

Usability enhancements:

* Updated placeholder text logic to dynamically use the field label in both the builder UI and generated form, ensuring consistency and clarity for users. (`formsync/frontend/src/builder/RightPanel.tsx` [[1]](diffhunk://#diff-062111f07ce18ed463eb0f5f502d1635757b3e9c80c00f279cc580235a6ae8f2L293-R293) `formsync/frontend/src/context/BuilderContext.tsx` [[2]](diffhunk://#diff-714a02514b603d9c280081f904ff97d3c55bfe56017e6ed99b8f983458c0e9c6R286-R295) `formsync/services/formgen-service/src/generators/react-generator.ts` [[3]](diffhunk://#diff-72963a081da83546612b9b345dbf80cf726d64b98225b8935adeb30f0f7ed45dR173-R193)
* Set `noValidate` on generated forms to disable native browser validation, allowing custom error handling and accessibility features to take precedence. (`formsync/services/formgen-service/src/generators/react-generator.ts` [[1]](diffhunk://#diff-72963a081da83546612b9b345dbf80cf726d64b98225b8935adeb30f0f7ed45dL50-R50) [[2]](diffhunk://#diff-72963a081da83546612b9b345dbf80cf726d64b98225b8935adeb30f0f7ed45dL66-R66)