### PR TITLE
Tddilk/releasev2 16 documentation and openapi plugins

### DIFF
--- a/formsync/package-lock.json
+++ b/formsync/package-lock.json
@@ -20118,6 +20118,7 @@
         "express": "^5.2.1",
         "fs-extra": "^11.3.3",
         "handlebars": "^4.7.8",
+        "js-yaml": "^4.1.1",
         "typescript": "^5.2.2",
         "uuid": "^13.0.0"
       },

--- a/formsync/services/backend-dto-generator/src/generator/BackendGenerator.ts
+++ b/formsync/services/backend-dto-generator/src/generator/BackendGenerator.ts
@@ -7,6 +7,12 @@ import { TemplateService } from '../service/TemplateService';
 import { FileWriter } from '../service/FileWriter';
 import * as path from 'path';
 
+/** Derives a Java base package from a schema name (e.g. "Employee" -> "com.employee"). */
+function schemaNameToBasePackage(name: string): string {
+    const normalized = name.toLowerCase().replace(/[^a-z0-9]/g, '') || 'app';
+    return `com.${normalized}`;
+}
+
 export class BackendGenerator extends BasePlugin implements BackendGeneratorPlugin {
     private mapper: SchemaMapper;
     private templateService: TemplateService;
@@ -24,7 +30,10 @@ export class BackendGenerator extends BasePlugin implements BackendGeneratorPlug
 
         // Default config values
         const outputDir = config?.outputDir || './generated-output';
-        const basePackage = config?.basePackage || 'com.example.demo';
+        const schemaName = (schema.content && (schema.name || schema.id))
+            ? String(schema.name || schema.id)
+            : (schema.title || 'App');
+        const basePackage = config?.basePackage ?? schemaNameToBasePackage(schemaName);
         const packagePath = basePackage.replace(/\./g, '/');
 
         try {

--- a/formsync/services/runtime-binding-engine/README.md
+++ b/formsync/services/runtime-binding-engine/README.md
@@ -298,6 +298,126 @@ npm test
 
 ---
 
+## Testing OpenAPI & Swagger
+
+Use these steps to verify that **OpenAPI spec generation** and **Swagger** work correctly.
+
+### 1. Start the Runtime Binding Engine
+
+From this directory:
+
+```bash
+npm run dev
+```
+
+By default it listens on **3013** (or the port in `RUNTIME_ENGINE_PORT` / `PORT`). Use that as `$ENGINE_URL` below (e.g. `http://localhost:3013`).
+
+### 2. Test OpenAPI spec generation (Phase 1)
+
+Request a **preview** (JSON list of generated files) and confirm `openapi.yaml` is present and valid:
+
+```bash
+curl -s -X POST http://localhost:3013/generate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Employee",
+      "type": "object",
+      "properties": {
+        "fullName": { "type": "string" },
+        "email": { "type": "string", "format": "email" }
+      },
+      "required": ["fullName", "email"]
+    },
+    "config": { "includeSwagger": true },
+    "preview": true
+  }' | jq '.files[] | select(.path | test("openapi\\.yaml")) | .path'
+```
+
+You should see:
+
+- `openapi.yaml`
+- `src/main/resources/static/openapi.yaml`
+
+To inspect the spec content (first 80 lines):
+
+```bash
+curl -s -X POST http://localhost:3013/generate \
+  -H "Content-Type: application/json" \
+  -d '{"schema":{"$schema":"http://json-schema.org/draft-07/schema#","title":"Employee","type":"object","properties":{"fullName":{"type":"string"},"email":{"type":"string","format":"email"}},"required":["fullName","email"]},"config":{"includeSwagger":true},"preview":true}' \
+  | jq -r '.files[] | select(.path == "openapi.yaml") | .content' | head -80
+```
+
+Check for `openapi: 3.0.3`, `info:`, `paths:`, and `components.schemas:` (e.g. `EmployeeRequest`, `EmployeeResponse`).
+
+### 3. Test Swagger in the generated backend (Phase 2)
+
+Generate a zip, unzip, run the Spring Boot app, then open Swagger UI.
+
+**3a. Generate and unzip**
+
+```bash
+curl -s -X POST http://localhost:3013/generate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "schema": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Employee",
+      "type": "object",
+      "properties": {
+        "fullName": { "type": "string" },
+        "email": { "type": "string", "format": "email" }
+      },
+      "required": ["fullName", "email"]
+    },
+    "config": { "includeSwagger": true, "serverPort": 8080 }
+  }' -o /tmp/springboot-server.zip
+
+unzip -o /tmp/springboot-server.zip -d /tmp/springboot-server
+cd /tmp/springboot-server
+```
+
+**3b. Build and run**
+
+```bash
+mvn clean spring-boot:run
+```
+
+**3c. Verify**
+
+- **Swagger UI**: Open **http://localhost:8080/swagger-ui.html**  
+  You should see the API title (e.g. "Employee"), tags, and CRUD operations (GET/POST/PUT/DELETE) with descriptions and request/response schemas.
+
+- **OpenAPI JSON**: Open **http://localhost:8080/v3/api-docs**  
+  You should get a JSON document with `openapi`, `info`, `paths`, and `components.schemas`.
+
+- **Static openapi.yaml**: If the app serves static resources, **http://localhost:8080/openapi.yaml** may serve the generated spec (depending on static path config).
+
+**3d. Quick API check**
+
+```bash
+# List (empty at first)
+curl -s http://localhost:8080/api/employees
+
+# Create one
+curl -s -X POST http://localhost:8080/api/employees \
+  -H "Content-Type: application/json" \
+  -d '{"fullName":"Jane Doe","email":"jane@example.com"}'
+```
+
+### 4. Optional: run the test script
+
+From the runtime-binding-engine directory you can run:
+
+```bash
+./scripts/test-openapi-swagger.sh
+```
+
+This script runs step 2 (preview + openapi.yaml check) and prints what to do for step 3 (generate zip, run server, open Swagger UI). It requires `curl` and `jq`.
+
+---
+
 ## Environment Variables
 
 | Variable          | Default                              | Description                         |

--- a/formsync/services/runtime-binding-engine/openapi-refined.yaml
+++ b/formsync/services/runtime-binding-engine/openapi-refined.yaml
@@ -1,0 +1,376 @@
+# -----------------------------------------------------------------------------
+# OpenAPI 3.0.3 — Refactored from auto-generated spec
+# -----------------------------------------------------------------------------
+# Summary of improvements:
+# 1. Domain & naming: Replaced incorrect entity name "OpenAPI" with
+#    "Job Application". Paths changed from /api/open-a-p-is to
+#    /api/job-applications. Schemas renamed from OpenAPIRequest/OpenAPIResponse
+#    to JobApplicationRequest/JobApplicationResponse.
+# 2. RESTful design: Plural resource path, consistent tags and operationIds.
+# 3. Schemas: Expanded address from a bare "object" into a full Address
+#    component (street, city, state, postalCode, country). Preserved
+#    validation (minLength, maxLength, enum, format, minimum, maximum).
+# 4. Error responses: Added reusable ErrorResponse schema; 400, 404, and 500
+#    now document a structured response body.
+# 5. Documentation: Clear summaries, descriptions, and operationIds; single
+#    tag "Job Applications" for all operations.
+# 6. Spring Boot alignment: CRUD-only, DTO-style request/response models,
+#    validation constraints suitable for @Valid and Bean Validation.
+# -----------------------------------------------------------------------------
+
+openapi: 3.0.3
+
+info:
+  title: Job Applications API
+  description: |
+    REST API for managing job applications (candidate submissions).
+    Designed for a Spring Boot backend with DTOs and Bean Validation.
+  version: 1.0.0
+
+servers:
+  - url: http://localhost:8080
+    description: Local development server
+
+paths:
+  /api/job-applications:
+    get:
+      tags:
+        - Job Applications
+      summary: List all job applications
+      description: Returns all job applications. Order is not guaranteed.
+      operationId: listJobApplications
+      responses:
+        '200':
+          description: List of job applications.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/JobApplicationResponse'
+              example:
+                - id: 1
+                  fullName: Jane Doe
+                  email: jane.doe@example.com
+                  department: Engineering
+                  experienceLevel: Senior
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - Job Applications
+      summary: Create a job application
+      description: Submits a new job application. Request body is validated.
+      operationId: createJobApplication
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobApplicationRequest'
+            example:
+              fullName: John Smith
+              email: john.smith@example.com
+              dateOfBirth: '1990-05-15'
+              salary: 95000
+              department: Engineering
+              experienceLevel: Mid-level
+              address:
+                street: 123 Main St
+                city: San Francisco
+                state: CA
+                postalCode: '94102'
+                country: USA
+              startDate: '2026-04-01'
+      responses:
+        '201':
+          description: Job application created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobApplicationResponse'
+        '400':
+          description: Validation error (invalid or missing fields).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /api/job-applications/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: Unique identifier of the job application.
+        schema:
+          type: integer
+          format: int64
+          minimum: 1
+    get:
+      tags:
+        - Job Applications
+      summary: Get job application by ID
+      description: Returns a single job application by its ID.
+      operationId: getJobApplicationById
+      responses:
+        '200':
+          description: Job application found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobApplicationResponse'
+        '404':
+          description: Job application not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    put:
+      tags:
+        - Job Applications
+      summary: Update a job application
+      description: Updates an existing job application by ID. Request body is validated.
+      operationId: updateJobApplication
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobApplicationRequest'
+      responses:
+        '200':
+          description: Job application updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobApplicationResponse'
+        '400':
+          description: Validation error (invalid or missing fields).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Job application not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - Job Applications
+      summary: Delete a job application
+      description: Deletes a job application by ID. Returns no content on success.
+      operationId: deleteJobApplication
+      responses:
+        '204':
+          description: Job application deleted. No response body.
+        '404':
+          description: Job application not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  schemas:
+    JobApplicationRequest:
+      type: object
+      description: Request body for creating or updating a job application.
+      required:
+        - fullName
+        - email
+      properties:
+        fullName:
+          type: string
+          description: Full name of the applicant.
+          minLength: 1
+          maxLength: 100
+          example: Jane Doe
+        email:
+          type: string
+          format: email
+          description: Email address of the applicant.
+          example: jane.doe@example.com
+        dateOfBirth:
+          type: string
+          format: date
+          description: Date of birth (YYYY-MM-DD).
+          example: '1990-05-15'
+        salary:
+          type: number
+          description: Expected or current salary. Must be non-negative.
+          minimum: 0
+          example: 95000
+        department:
+          type: string
+          description: Department or area of interest.
+          enum:
+            - Engineering
+            - Design
+            - Product
+            - Sales
+            - HR
+            - Finance
+          example: Engineering
+        experienceLevel:
+          type: string
+          description: Professional experience level.
+          enum:
+            - Junior
+            - Mid-level
+            - Senior
+            - Lead
+            - Principal
+          example: Senior
+        startDate:
+          type: string
+          format: date
+          description: Earliest available start date (YYYY-MM-DD).
+          example: '2026-04-01'
+        address:
+          $ref: '#/components/schemas/Address'
+
+    JobApplicationResponse:
+      type: object
+      description: Job application as returned by the API (includes server-assigned ID).
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Unique identifier assigned by the server.
+          example: 1
+        fullName:
+          type: string
+          description: Full name of the applicant.
+        email:
+          type: string
+          format: email
+          description: Email address of the applicant.
+        dateOfBirth:
+          type: string
+          format: date
+          description: Date of birth (YYYY-MM-DD).
+        salary:
+          type: number
+          description: Salary value.
+        department:
+          type: string
+          enum:
+            - Engineering
+            - Design
+            - Product
+            - Sales
+            - HR
+            - Finance
+        experienceLevel:
+          type: string
+          enum:
+            - Junior
+            - Mid-level
+            - Senior
+            - Lead
+            - Principal
+        startDate:
+          type: string
+          format: date
+          description: Earliest available start date (YYYY-MM-DD).
+        address:
+          $ref: '#/components/schemas/Address'
+
+    Address:
+      type: object
+      description: Postal address (nested in job application).
+      properties:
+        street:
+          type: string
+          description: Street address line.
+          maxLength: 200
+          example: 123 Main St
+        city:
+          type: string
+          description: City name.
+          maxLength: 100
+          example: San Francisco
+        state:
+          type: string
+          description: State, province, or region.
+          maxLength: 100
+          example: CA
+        postalCode:
+          type: string
+          description: Postal or ZIP code.
+          pattern: '^[0-9]{5}(-[0-9]{4})?$'
+          maxLength: 20
+          example: '94102'
+        country:
+          type: string
+          description: Country name or code.
+          maxLength: 100
+          example: USA
+
+    ErrorResponse:
+      type: object
+      description: Standard error payload for 400, 404, and 500 responses.
+      properties:
+        status:
+          type: integer
+          description: HTTP status code.
+          example: 400
+        error:
+          type: string
+          description: Error type or category.
+          example: Validation Failed
+        message:
+          type: string
+          description: Human-readable error message.
+          example: Request body has 2 validation error(s).
+        path:
+          type: string
+          description: Request path that caused the error.
+          example: /api/job-applications
+        timestamp:
+          type: string
+          format: date-time
+          description: Time when the error occurred (ISO-8601).
+        validationErrors:
+          type: array
+          description: Field-level validation errors (present for 400 responses).
+          items:
+            type: object
+            properties:
+              field:
+                type: string
+                example: email
+              message:
+                type: string
+                example: must be a valid email address
+              rejectedValue: {}

--- a/formsync/services/runtime-binding-engine/package.json
+++ b/formsync/services/runtime-binding-engine/package.json
@@ -14,16 +14,17 @@
         "format": "prettier --write \"src/**/*.ts\""
     },
     "dependencies": {
-        "dotenv": "^16.3.1",
         "archiver": "^7.0.1",
         "axios": "^1.13.2",
         "axios-retry": "^4.5.0",
         "body-parser": "^2.2.1",
         "cors": "^2.8.5",
         "cpx": "^1.5.0",
+        "dotenv": "^16.3.1",
         "express": "^5.2.1",
         "fs-extra": "^11.3.3",
         "handlebars": "^4.7.8",
+        "js-yaml": "^4.1.1",
         "typescript": "^5.2.2",
         "uuid": "^13.0.0"
     },

--- a/formsync/services/runtime-binding-engine/src/generator/SpringBootGenerator.ts
+++ b/formsync/services/runtime-binding-engine/src/generator/SpringBootGenerator.ts
@@ -3,7 +3,15 @@ import { InternalSchema } from '../model/InternalModel';
 import { SpringBootGeneratorConfig } from '../model/InputContract';
 import { TemplateService } from '../service/TemplateService';
 import { FileWriter } from '../service/FileWriter';
+import { buildOpenApiSpec } from '../openapi/OpenApiSpecBuilder';
+import * as yaml from 'js-yaml';
 import * as path from 'path';
+
+/** Derives a Java base package from a schema name (e.g. "Employee" -> "com.employee"). */
+function schemaNameToBasePackage(name: string): string {
+    const normalized = name.toLowerCase().replace(/[^a-z0-9]/g, '') || 'app';
+    return `com.${normalized}`;
+}
 
 /**
  * Generates a complete, ready-to-run Spring Boot backend server
@@ -35,11 +43,9 @@ export class SpringBootGenerator {
 
     async generate(schema: any, config?: SpringBootGeneratorConfig): Promise<void> {
         const outputDir = config?.outputDir || './generated-output';
-        const basePackage = config?.basePackage || 'com.example.demo';
         const serverPort = config?.serverPort || 8080;
         const includeSwagger = config?.includeSwagger ?? true;
         const database = config?.database || 'h2';
-        const packagePath = basePackage.replace(/\./g, '/');
 
         try {
             let internalModel: InternalSchema;
@@ -55,6 +61,8 @@ export class SpringBootGenerator {
             }
 
             const appName = internalModel.appName;
+            const basePackage = config?.basePackage ?? schemaNameToBasePackage(appName);
+            const packagePath = basePackage.replace(/\./g, '/');
 
             // ── 1. pom.xml ──
             const pomContent = this.templateService.render('pom', {
@@ -72,7 +80,10 @@ export class SpringBootGenerator {
                 name: appName,
                 serverPort,
                 basePackage,
-                database
+                database,
+                includeSwagger,
+                version: internalModel.version,
+                description: internalModel.description
             });
             this.fileWriter.write(
                 path.join(outputDir, 'src/main/resources/application.yml'),
@@ -108,6 +119,20 @@ export class SpringBootGenerator {
                 exHandlerContent
             );
 
+            // ── 4b. OpenAPI config (when Swagger enabled) ──
+            if (includeSwagger) {
+                const openApiConfigContent = this.templateService.render('openapi-config', {
+                    basePackage,
+                    appName,
+                    version: internalModel.version,
+                    description: internalModel.description,
+                });
+                this.fileWriter.write(
+                    path.join(outputDir, 'src/main/java', packagePath, 'config', 'OpenApiConfig.java'),
+                    openApiConfigContent
+                );
+            }
+
             // ── 5. Enums ──
             for (const enumDef of internalModel.enums) {
                 const enumContent = this.templateService.render('enum', {
@@ -120,10 +145,27 @@ export class SpringBootGenerator {
                 );
             }
 
+            // ── 5b. OpenAPI 3 spec (openapi.yaml) ──
+            const openApiDoc = buildOpenApiSpec(internalModel);
+            const openApiYaml = yaml.dump(openApiDoc, { lineWidth: -1 });
+            this.fileWriter.write(path.join(outputDir, 'openapi.yaml'), openApiYaml);
+            this.fileWriter.write(
+                path.join(outputDir, 'src/main/resources/static/openapi.yaml'),
+                openApiYaml
+            );
+
             // ── 6. Per-entity generation ──
             for (const entity of internalModel.entities) {
                 const nameLower = entity.name.charAt(0).toLowerCase() + entity.name.slice(1);
-                const context = { ...entity, basePackage, nameLower };
+                const context = {
+                    ...entity,
+                    basePackage,
+                    nameLower,
+                    includeSwagger,
+                    appName,
+                    version: internalModel.version,
+                    description: internalModel.description
+                };
 
                 // Entity
                 const entityContent = this.templateService.render('entity', context);

--- a/formsync/services/runtime-binding-engine/src/openapi/OpenApiSpecBuilder.ts
+++ b/formsync/services/runtime-binding-engine/src/openapi/OpenApiSpecBuilder.ts
@@ -1,0 +1,382 @@
+import {
+    InternalSchema,
+    SchemaEntity,
+    SchemaField,
+    DataType,
+    SchemaEnum,
+} from '../model/InternalModel';
+
+/** Converts a string to kebab-case (e.g. "EmployeeOnboarding" -> "employee-onboarding"). */
+function toKebabCase(str: string): string {
+    return str
+        .replace(/[\s_]+/g, '-')
+        .replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)
+        .toLowerCase()
+        .replace(/^-/, '')
+        .replace(/-{2,}/g, '-');
+}
+
+/** Pluralized kebab-case resource path segment (e.g. "Employee" -> "employees"). */
+function resourcePathSegment(entityName: string): string {
+    const kebab = toKebabCase(entityName);
+    return kebab + 's';
+}
+
+/** OpenAPI 3.0 schema object for a single property. */
+interface OpenApiSchemaProperty {
+    type?: string;
+    format?: string;
+    description?: string;
+    example?: string | number | boolean;
+    enum?: string[];
+    items?: Record<string, unknown>;
+    required?: string[];
+}
+
+/**
+ * Build OpenAPI 3.0 schema for a field.
+ * When useRefForCompositeTypes is true, ENUM and OBJECT (with referenceType) are emitted as $ref
+ * so they appear as separate entries in components.schemas (and in the Schemas tab).
+ */
+function fieldToOpenApiSchema(
+    field: SchemaField,
+    enums: SchemaEnum[],
+    useRefForCompositeTypes = false
+): Record<string, unknown> {
+    if (useRefForCompositeTypes && field.type === DataType.ENUM && field.referenceType) {
+        return { $ref: `#/components/schemas/${field.referenceType}` };
+    }
+    if (useRefForCompositeTypes && (field.type === DataType.OBJECT || field.type === DataType.MAP) && field.referenceType) {
+        return { $ref: `#/components/schemas/${field.referenceType}` };
+    }
+
+    const schema: OpenApiSchemaProperty = {};
+    if (field.description) schema.description = field.description;
+    if (field.constraints.example !== undefined) schema.example = field.constraints.example;
+
+    switch (field.type) {
+        case DataType.STRING:
+            schema.type = 'string';
+            if (field.constraints.email) schema.format = 'email';
+            if (field.constraints.minLength !== undefined) (schema as any).minLength = field.constraints.minLength;
+            if (field.constraints.maxLength !== undefined) (schema as any).maxLength = field.constraints.maxLength;
+            if (field.constraints.pattern) (schema as any).pattern = field.constraints.pattern;
+            break;
+        case DataType.INTEGER:
+            schema.type = 'integer';
+            if (field.constraints.min !== undefined) (schema as any).minimum = field.constraints.min;
+            if (field.constraints.max !== undefined) (schema as any).maximum = field.constraints.max;
+            break;
+        case DataType.LONG:
+            schema.type = 'integer';
+            schema.format = 'int64';
+            if (field.constraints.min !== undefined) (schema as any).minimum = field.constraints.min;
+            if (field.constraints.max !== undefined) (schema as any).maximum = field.constraints.max;
+            break;
+        case DataType.DOUBLE:
+        case DataType.BIG_DECIMAL:
+            schema.type = 'number';
+            if (field.constraints.min !== undefined) (schema as any).minimum = field.constraints.min;
+            if (field.constraints.max !== undefined) (schema as any).maximum = field.constraints.max;
+            break;
+        case DataType.BOOLEAN:
+            schema.type = 'boolean';
+            break;
+        case DataType.LOCAL_DATE:
+            schema.type = 'string';
+            schema.format = 'date';
+            break;
+        case DataType.LOCAL_DATE_TIME:
+            schema.type = 'string';
+            schema.format = 'date-time';
+            break;
+        case DataType.ENUM:
+            schema.type = 'string';
+            if (field.referenceType) {
+                const enumDef = enums.find((e) => e.name === field.referenceType);
+                if (enumDef?.values?.length) schema.enum = enumDef.values;
+            }
+            break;
+        case DataType.LIST:
+        case DataType.SET:
+            schema.type = 'array';
+            if (field.itemType) {
+                const itemSchema = fieldToOpenApiSchema(
+                    {
+                        name: 'item',
+                        type: field.itemType,
+                        referenceType: field.itemReferenceType,
+                        constraints: {},
+                    } as SchemaField,
+                    enums,
+                    useRefForCompositeTypes
+                );
+                schema.items = itemSchema;
+            } else {
+                schema.items = { type: 'string' };
+            }
+            break;
+        case DataType.MAP:
+        case DataType.OBJECT:
+            schema.type = 'object';
+            break;
+        default:
+            schema.type = 'string';
+    }
+
+    return schema as Record<string, unknown>;
+}
+
+/** Build Request schema for an entity (properties from fields only). Uses $ref for enums and nested objects. */
+function buildRequestSchema(entity: SchemaEntity, enums: SchemaEnum[]): Record<string, unknown> {
+    const properties: Record<string, Record<string, unknown>> = {};
+    const required: string[] = [];
+
+    for (const field of entity.fields) {
+        properties[field.name] = fieldToOpenApiSchema(field, enums, true);
+        if (field.constraints.required) required.push(field.name);
+    }
+
+    const schema: Record<string, unknown> = {
+        type: 'object',
+        properties,
+    };
+    if (required.length) schema.required = required;
+    return schema;
+}
+
+/** Build Response schema for an entity (id + fields). Uses $ref for enums and nested objects. */
+function buildResponseSchema(entity: SchemaEntity, enums: SchemaEnum[]): Record<string, unknown> {
+    const properties: Record<string, Record<string, unknown>> = {
+        id: {
+            type: 'integer',
+            format: 'int64',
+            description: 'Entity ID',
+        } as Record<string, unknown>,
+    };
+
+    for (const field of entity.fields) {
+        properties[field.name] = fieldToOpenApiSchema(field, enums, true);
+    }
+
+    return {
+        type: 'object',
+        properties,
+    };
+}
+
+/** Build a reusable component schema for a nested entity (e.g. Address). */
+function buildEntitySchema(entity: SchemaEntity, enums: SchemaEnum[]): Record<string, unknown> {
+    const properties: Record<string, Record<string, unknown>> = {};
+    const required: string[] = [];
+
+    for (const field of entity.fields) {
+        properties[field.name] = fieldToOpenApiSchema(field, enums, true);
+        if (field.constraints.required) required.push(field.name);
+    }
+
+    const schema: Record<string, unknown> = {
+        type: 'object',
+        description: entity.description || undefined,
+        properties,
+    };
+    if (required.length) schema.required = required;
+    return schema;
+}
+
+/** OpenAPI 3.0 document structure (subset we use). */
+export interface OpenApiDocument {
+    openapi: string;
+    info: { title: string; description?: string; version: string };
+    paths: Record<string, Record<string, unknown>>;
+    components: { schemas: Record<string, Record<string, unknown>> };
+}
+
+/**
+ * Builds an OpenAPI 3.0 specification from InternalSchema.
+ * Produces paths and components.schemas for all root entities (CRUD).
+ * Ensures all models appear in the Schemas tab: enums, nested entities (e.g. Address), Request/Response DTOs.
+ */
+export function buildOpenApiSpec(schema: InternalSchema): OpenApiDocument {
+    const rootEntities = schema.entities.filter((e) => e.isRoot);
+    const nestedEntities = schema.entities.filter((e) => !e.isRoot);
+    const paths: Record<string, Record<string, unknown>> = {};
+    const componentsSchemas: Record<string, Record<string, unknown>> = {};
+
+    // 1. Add all enums as separate schemas so they appear in the Schemas tab
+    for (const enumDef of schema.enums) {
+        componentsSchemas[enumDef.name] = {
+            type: 'string',
+            enum: enumDef.values,
+            description: `Enum: ${enumDef.name}`,
+        } as Record<string, unknown>;
+    }
+
+    // 2. Add all nested entities (e.g. Address) as separate schemas
+    for (const entity of nestedEntities) {
+        componentsSchemas[entity.name] = buildEntitySchema(entity, schema.enums);
+    }
+
+    // 3. Add root entity model schema so it appears in Schemas tab (4 models: nested + entity + enums; 2 DTOs: Request + Response)
+    for (const entity of rootEntities) {
+        componentsSchemas[entity.name] = buildEntitySchema(entity, schema.enums);
+    }
+
+    // 4. Add Request/Response DTOs and paths for each root entity
+    for (const entity of rootEntities) {
+        const resource = resourcePathSegment(entity.name);
+        const basePath = `/api/${resource}`;
+        const requestRef = `#/components/schemas/${entity.name}Request`;
+        const responseRef = `#/components/schemas/${entity.name}Response`;
+
+        componentsSchemas[`${entity.name}Request`] = buildRequestSchema(entity, schema.enums);
+        componentsSchemas[`${entity.name}Response`] = buildResponseSchema(entity, schema.enums);
+
+        const entityDesc = entity.description || entity.name;
+        const nameLower = entity.name.charAt(0).toLowerCase() + entity.name.slice(1);
+
+        // GET /api/{resource}
+        paths[basePath] = {
+            get: {
+                summary: `List all ${nameLower}s`,
+                description: `Retrieve all ${nameLower} entities.`,
+                operationId: `getAll${entity.name}s`,
+                tags: [entity.name],
+                responses: {
+                    '200': {
+                        description: 'List of entities',
+                        content: {
+                            'application/json': {
+                                schema: {
+                                    type: 'array',
+                                    items: { $ref: responseRef },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+            post: {
+                summary: `Create a new ${nameLower}`,
+                description: `Create a new ${nameLower}. Request body is validated.`,
+                operationId: `create${entity.name}`,
+                tags: [entity.name],
+                requestBody: {
+                    required: true,
+                    content: {
+                        'application/json': {
+                            schema: { $ref: requestRef },
+                        },
+                    },
+                },
+                responses: {
+                    '201': {
+                        description: 'Entity created',
+                        content: {
+                            'application/json': {
+                                schema: { $ref: responseRef },
+                            },
+                        },
+                    },
+                    '400': { description: 'Validation error' },
+                },
+            },
+        };
+
+        // GET /api/{resource}/{id}, PUT /api/{resource}/{id}, DELETE /api/{resource}/{id}
+        const pathWithId = `${basePath}/{id}`;
+        paths[pathWithId] = {
+            get: {
+                summary: `Get ${nameLower} by ID`,
+                description: `Retrieve a ${nameLower} by ID.`,
+                operationId: `get${entity.name}ById`,
+                tags: [entity.name],
+                parameters: [
+                    {
+                        name: 'id',
+                        in: 'path',
+                        required: true,
+                        schema: { type: 'integer', format: 'int64' },
+                        description: 'Entity ID',
+                    },
+                ],
+                responses: {
+                    '200': {
+                        description: 'Entity found',
+                        content: {
+                            'application/json': {
+                                schema: { $ref: responseRef },
+                            },
+                        },
+                    },
+                    '404': { description: 'Entity not found' },
+                },
+            },
+            put: {
+                summary: `Update ${nameLower}`,
+                description: `Update an existing ${nameLower}. Request body is validated.`,
+                operationId: `update${entity.name}`,
+                tags: [entity.name],
+                parameters: [
+                    {
+                        name: 'id',
+                        in: 'path',
+                        required: true,
+                        schema: { type: 'integer', format: 'int64' },
+                        description: 'Entity ID',
+                    },
+                ],
+                requestBody: {
+                    required: true,
+                    content: {
+                        'application/json': {
+                            schema: { $ref: requestRef },
+                        },
+                    },
+                },
+                responses: {
+                    '200': {
+                        description: 'Entity updated',
+                        content: {
+                            'application/json': {
+                                schema: { $ref: responseRef },
+                            },
+                        },
+                    },
+                    '400': { description: 'Validation error' },
+                    '404': { description: 'Entity not found' },
+                },
+            },
+            delete: {
+                summary: `Delete ${nameLower}`,
+                description: `Delete a ${nameLower} by ID.`,
+                operationId: `delete${entity.name}`,
+                tags: [entity.name],
+                parameters: [
+                    {
+                        name: 'id',
+                        in: 'path',
+                        required: true,
+                        schema: { type: 'integer', format: 'int64' },
+                        description: 'Entity ID',
+                    },
+                ],
+                responses: {
+                    '204': { description: 'Entity deleted' },
+                    '404': { description: 'Entity not found' },
+                },
+            },
+        };
+    }
+
+    return {
+        openapi: '3.0.3',
+        info: {
+            title: schema.appName,
+            description: schema.description || `Generated API for ${schema.appName}`,
+            version: schema.version,
+        },
+        paths,
+        components: { schemas: componentsSchemas },
+    };
+}

--- a/formsync/services/runtime-binding-engine/src/service/TemplateService.ts
+++ b/formsync/services/runtime-binding-engine/src/service/TemplateService.ts
@@ -91,6 +91,14 @@ export class TemplateService {
             return str.replace(/\\/g, '\\\\');
         });
 
+        /** Escapes a string for use inside Java @Schema(example = "...") */
+        handlebars.registerHelper('escapeSchemaExample', (str: string) => {
+            if (str == null) return '';
+            return String(str)
+                .replace(/\\/g, '\\\\')
+                .replace(/"/g, '\\"');
+        });
+
         handlebars.registerHelper('eq', function (this: any, arg1, arg2, options) {
             return (arg1 === arg2) ? options.fn(this) : options.inverse(this);
         });
@@ -324,6 +332,7 @@ export class TemplateService {
         this.loadTemplate('not-found-exception', path.join(templatesDir, 'java/not-found-exception.hbs'));
         this.loadTemplate('api-error', path.join(templatesDir, 'java/api-error.hbs'));
         this.loadTemplate('exception-handler', path.join(templatesDir, 'java/exception-handler.hbs'));
+        this.loadTemplate('openapi-config', path.join(templatesDir, 'java/openapi-config.hbs'));
 
         // README
         this.loadTemplate('readme', path.join(templatesDir, 'readme.hbs'));

--- a/formsync/services/runtime-binding-engine/src/templates/application-yml.hbs
+++ b/formsync/services/runtime-binding-engine/src/templates/application-yml.hbs
@@ -37,6 +37,15 @@ spring:
 
 server:
   port: {{serverPort}}
+{{#if includeSwagger}}
+
+# SpringDoc / OpenAPI
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+{{/if}}
 
 logging:
   level:

--- a/formsync/services/runtime-binding-engine/src/templates/java/controller.hbs
+++ b/formsync/services/runtime-binding-engine/src/templates/java/controller.hbs
@@ -7,6 +7,11 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+{{#if includeSwagger}}
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+{{/if}}
 
 import java.util.List;
 
@@ -14,6 +19,9 @@ import java.util.List;
  * REST Controller for {{name}} CRUD operations.
  * All request bodies are validated using Jakarta Bean Validation.
  */
+{{#if includeSwagger}}
+@Tag(name = "{{name}}", description = "{{#if description}}{{description}}{{else}}{{name}} CRUD operations{{/if}}")
+{{/if}}
 @RestController
 @RequestMapping("/api/{{toKebabCase name}}s")
 @CrossOrigin(origins = "*")
@@ -29,6 +37,10 @@ public class {{name}}Controller {
      * GET /api/{{toKebabCase name}}s
      * Retrieve all {{nameLower}}s.
      */
+    {{#if includeSwagger}}
+    @Operation(summary = "List all {{nameLower}}s", description = "Retrieve all {{nameLower}} entities.")
+    @ApiResponse(responseCode = "200", description = "List of entities")
+    {{/if}}
     @GetMapping
     public ResponseEntity<List<{{name}}Response>> getAll() {
         return ResponseEntity.ok(service.findAll());
@@ -38,6 +50,11 @@ public class {{name}}Controller {
      * GET /api/{{toKebabCase name}}s/{id}
      * Retrieve a {{nameLower}} by ID.
      */
+    {{#if includeSwagger}}
+    @Operation(summary = "Get {{nameLower}} by ID", description = "Retrieve a {{nameLower}} by ID.")
+    @ApiResponse(responseCode = "200", description = "Entity found")
+    @ApiResponse(responseCode = "404", description = "Entity not found")
+    {{/if}}
     @GetMapping("/{id}")
     public ResponseEntity<{{name}}Response> getById(@PathVariable Long id) {
         return ResponseEntity.ok(service.findById(id));
@@ -47,6 +64,11 @@ public class {{name}}Controller {
      * POST /api/{{toKebabCase name}}s
      * Create a new {{nameLower}}. Request body is validated.
      */
+    {{#if includeSwagger}}
+    @Operation(summary = "Create {{nameLower}}", description = "Create a new {{nameLower}}. Request body is validated.")
+    @ApiResponse(responseCode = "201", description = "Entity created")
+    @ApiResponse(responseCode = "400", description = "Validation error")
+    {{/if}}
     @PostMapping
     public ResponseEntity<{{name}}Response> create(@Valid @RequestBody {{name}}Request request) {
         {{name}}Response created = service.create(request);
@@ -57,6 +79,12 @@ public class {{name}}Controller {
      * PUT /api/{{toKebabCase name}}s/{id}
      * Update an existing {{nameLower}}. Request body is validated.
      */
+    {{#if includeSwagger}}
+    @Operation(summary = "Update {{nameLower}}", description = "Update an existing {{nameLower}}. Request body is validated.")
+    @ApiResponse(responseCode = "200", description = "Entity updated")
+    @ApiResponse(responseCode = "400", description = "Validation error")
+    @ApiResponse(responseCode = "404", description = "Entity not found")
+    {{/if}}
     @PutMapping("/{id}")
     public ResponseEntity<{{name}}Response> update(@PathVariable Long id, @Valid @RequestBody {{name}}Request request) {
         return ResponseEntity.ok(service.update(id, request));
@@ -66,6 +94,11 @@ public class {{name}}Controller {
      * DELETE /api/{{toKebabCase name}}s/{id}
      * Delete a {{nameLower}} by ID.
      */
+    {{#if includeSwagger}}
+    @Operation(summary = "Delete {{nameLower}}", description = "Delete a {{nameLower}} by ID.")
+    @ApiResponse(responseCode = "204", description = "Entity deleted")
+    @ApiResponse(responseCode = "404", description = "Entity not found")
+    {{/if}}
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         service.deleteById(id);

--- a/formsync/services/runtime-binding-engine/src/templates/java/dto-request.hbs
+++ b/formsync/services/runtime-binding-engine/src/templates/java/dto-request.hbs
@@ -6,6 +6,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+{{#if includeSwagger}}
+import io.swagger.v3.oas.annotations.media.Schema;
+{{/if}}
 import java.util.*;
 import java.time.*;
 import java.math.*;
@@ -14,6 +17,9 @@ import java.math.*;
  * Request DTO for creating/updating {{name}}.
  * Contains all validation constraints from the JSON Schema.
  */
+{{#if includeSwagger}}
+@Schema(description = "Request body for creating/updating {{name}}")
+{{/if}}
 @Data
 @Builder
 @NoArgsConstructor
@@ -21,6 +27,9 @@ import java.math.*;
 public class {{name}}Request {
 
 {{#each fields}}
+{{#if ../includeSwagger}}
+    @Schema(description = "{{#if description}}{{description}}{{else}}{{name}} field{{/if}}"{{#if constraints.required}}, required = true{{/if}}{{#if constraints.example}}, example = "{{escapeSchemaExample constraints.example}}"{{/if}})
+{{/if}}
 {{#if description}}
     /**
      * {{description}}

--- a/formsync/services/runtime-binding-engine/src/templates/java/dto-response.hbs
+++ b/formsync/services/runtime-binding-engine/src/templates/java/dto-response.hbs
@@ -5,6 +5,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+{{#if includeSwagger}}
+import io.swagger.v3.oas.annotations.media.Schema;
+{{/if}}
 import java.util.*;
 import java.time.*;
 import java.math.*;
@@ -12,15 +15,24 @@ import java.math.*;
 /**
  * Response DTO for {{name}}.
  */
+{{#if includeSwagger}}
+@Schema(description = "Response for {{name}}")
+{{/if}}
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class {{name}}Response {
 
+    {{#if includeSwagger}}
+    @Schema(description = "Entity ID")
+    {{/if}}
     private Long id;
 
 {{#each fields}}
+{{#if ../includeSwagger}}
+    @Schema(description = "{{#if description}}{{description}}{{else}}{{name}} field{{/if}}")
+{{/if}}
 {{#if description}}
     /**
      * {{description}}

--- a/formsync/services/runtime-binding-engine/src/templates/java/enum.hbs
+++ b/formsync/services/runtime-binding-engine/src/templates/java/enum.hbs
@@ -2,7 +2,9 @@ package {{basePackage}}.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "Enum: {{name}}", enumAsRef = true)
 public enum {{name}} {
 {{#each values}}
     {{toEnumConstant this}}("{{this}}"){{#unless @last}},{{/unless}}{{#if @last}};{{/if}}

--- a/formsync/services/runtime-binding-engine/src/templates/java/openapi-config.hbs
+++ b/formsync/services/runtime-binding-engine/src/templates/java/openapi-config.hbs
@@ -1,0 +1,30 @@
+package {{basePackage}}.config;
+
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * OpenAPI / Swagger configuration.
+ * Sets API title, description, and version. Ensures enums appear as separate schemas in the Schemas tab.
+ */
+@Configuration
+public class OpenApiConfig {
+
+    @PostConstruct
+    public void init() {
+        ModelResolver.enumsAsRef = true;
+    }
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("{{appName}}")
+                        .description("{{#if description}}{{description}}{{else}}Generated API for {{appName}}{{/if}}")
+                        .version("{{version}}"));
+    }
+}

--- a/formsync/services/runtime-binding-engine/src/templates/readme.hbs
+++ b/formsync/services/runtime-binding-engine/src/templates/readme.hbs
@@ -25,6 +25,10 @@ mvn spring-boot:run
 
 The server starts at **http://localhost:{{serverPort}}**
 
+### OpenAPI specification
+
+An **OpenAPI 3.0** specification is included as `openapi.yaml` in the project root (and at `src/main/resources/static/openapi.yaml`). Use it for API contracts, code generation, or documentation without running the server.
+
 {{#eq database 'h2'}}
 ### H2 In-Memory Database Console
 
@@ -40,7 +44,10 @@ The H2 console is available at: **http://localhost:{{serverPort}}/h2-console**
 
 ### Swagger UI
 
-API documentation is available at: **http://localhost:{{serverPort}}/swagger-ui.html**
+- **Swagger UI**: **http://localhost:{{serverPort}}/swagger-ui.html**
+- **OpenAPI JSON**: **http://localhost:{{serverPort}}/v3/api-docs** (for tooling or export)
+
+For offline use, see the **openapi.yaml** file in the project root.
 {{/if}}
 
 ---


### PR DESCRIPTION
This pull request introduces improvements to OpenAPI/Swagger support in the Spring Boot backend generator, refines domain naming conventions, and enhances documentation and error handling. The changes ensure that generated APIs are RESTful, properly documented, and aligned with Spring Boot best practices. Key updates include domain-specific OpenAPI schemas, improved error response models, and more flexible package naming.

**OpenAPI & Swagger improvements:**

* Added a refined `openapi-refined.yaml` example with domain-specific naming, RESTful resource paths, expanded schemas (including a detailed `Address` component), structured error responses, and improved documentation for generated APIs.
* Updated the Spring Boot generator (`SpringBootGenerator.ts`) to produce OpenAPI 3 specs (`openapi.yaml`) using a new builder, and write them to both the project root and static resources folder.
* Added OpenAPI configuration file generation (`OpenApiConfig.java`) when Swagger is enabled, using template variables for package, app name, version, and description.

**Domain naming and package improvements:**

* Introduced a utility for deriving Java base package names from schema/app names, replacing hardcoded defaults, and applied this logic in both backend generators for more consistent package structure. [[1]](diffhunk://#diff-8d4d9c5540eba776d7e18c56ae0833cb6d3b483a85918241f83e791d83853b9cR10-R15) [[2]](diffhunk://#diff-8d4d9c5540eba776d7e18c56ae0833cb6d3b483a85918241f83e791d83853b9cL27-R36) [[3]](diffhunk://#diff-cda36fb4af85ef5ef299697fccef89dc2ed02924a440bff930aec4a4fe1c8707R6-R15) [[4]](diffhunk://#diff-cda36fb4af85ef5ef299697fccef89dc2ed02924a440bff930aec4a4fe1c8707R64-R65)

**Documentation and testing:**

* Added detailed instructions in the `README.md` for testing OpenAPI spec generation and Swagger UI, including curl commands and validation steps.

**Dependency updates:**

* Added `js-yaml` as a dependency in relevant `package.json` and `package-lock.json` files to support YAML serialization for OpenAPI spec generation. [[1]](diffhunk://#diff-4ba9f78eb8026645976604a02781cc284752c4cf8179f4e94ad84934286397bbL17-R27) [[2]](diffhunk://#diff-08d6e618f5bf43832f4be0a2bcdc9d2f93e2c19c2cd1e7d5fdb3da4a0f4a2419R20121)