### PR TITLE
109 implement srs to form generation via user story extraction

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(npx prisma *)",
-      "Bash(npm install *)"
-    ]
-  }
-}

--- a/formsync/frontend/src/components/UserStorySelectorModal.tsx
+++ b/formsync/frontend/src/components/UserStorySelectorModal.tsx
@@ -168,6 +168,7 @@ export const UserStorySelectorModal: React.FC<Props> = ({
       if (pid) {
         toast.success(`Project "${projectName}" saved with ${result.totalFound} stories`);
         onClose();
+        navigate("/profile?tab=projects");
       } else {
         toast.error("Failed to save project");
       }

--- a/formsync/frontend/src/pages/ProfilePage.tsx
+++ b/formsync/frontend/src/pages/ProfilePage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useNavigate, Link } from "react-router-dom";
+import { useNavigate, useSearchParams, Link } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { useAuth } from "../context/AuthContext";
 import { authService } from "../services/authService";
@@ -443,6 +443,7 @@ const ProjectDetailModal: React.FC<{
 export const ProfilePage: React.FC = () => {
   const { user, token, logout, isLoading: authLoading, updateUser } = useAuth();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
 
   const [headerName, setHeaderName] = useState<string | null>(null);
   const [headerEmail, setHeaderEmail] = useState<string | null>(null);
@@ -457,7 +458,8 @@ export const ProfilePage: React.FC = () => {
     setHeaderEmail(updated.email);
   };
 
-  const [activeTab, setActiveTab] = useState<"schemas" | "projects">("schemas");
+  const initialTab = searchParams.get("tab") === "projects" ? "projects" : "schemas";
+  const [activeTab, setActiveTab] = useState<"schemas" | "projects">(initialTab);
   const [schemas, setSchemas] = useState<any[]>([]);
   const [projects, setProjects] = useState<SrsProject[]>([]);
   const [loadingSchemas, setLoadingSchemas] = useState(false);


### PR DESCRIPTION
This pull request introduces improvements to the user experience on the profile and project management pages. The main change is that after saving a project, users are now automatically navigated to their profile page with the "projects" tab selected. This required updating the tab selection logic on the profile page to respect the URL parameter, and some related code cleanups.

User navigation and profile tab improvements:

* After saving a project in `UserStorySelectorModal`, users are now redirected to `/profile?tab=projects` so they immediately see their updated projects list.
* The `ProfilePage` component now reads the `tab` parameter from the URL using `useSearchParams` and sets the initial active tab accordingly, defaulting to "schemas" if not specified. [[1]](diffhunk://#diff-3a877e7dfbdd6699106b8e95d3b76263836dc7d7401c0a64e3fc22707f084896R446) [[2]](diffhunk://#diff-3a877e7dfbdd6699106b8e95d3b76263836dc7d7401c0a64e3fc22707f084896L460-R462)
* Imported `useSearchParams` in `ProfilePage.tsx` to support the new tab selection logic.

Other changes:

* Removed the local `.claude/settings.local.json` permissions file, likely as cleanup or because it's no longer needed.