### PR TITLE
133 add html bootstrap javascript frontend code generation support

### DIFF
--- a/formsync/docker-compose.yml
+++ b/formsync/docker-compose.yml
@@ -11,6 +11,7 @@
 #    formgen-service           → Express               :3014
 #    node-backend-generator    → Express               :3015
 #    dotnet-backend-generator  → Express               :3016
+#    static-frontend-generator → Express               :3017
 #    frontend                  → React (nginx)         :5173
 #
 #  Usage:
@@ -40,6 +41,7 @@ x-common-env: &common-env
   FORMGEN_SERVICE_PORT: 3014
   NODE_BACKEND_GENERATOR_PORT: 3015
   DOTNET_BACKEND_GENERATOR_PORT: 3016
+  STATIC_FRONTEND_GENERATOR_PORT: 3017
   # ── Internal URLs (Docker service names, not localhost) ───
   SCHEMA_ENGINE_URL: http://schema-enhancement-engine:3010
   USER_SERVICE_URL: http://user-management-service:3011
@@ -50,6 +52,7 @@ x-common-env: &common-env
   FRONTEND_URL: http://localhost
   NODE_BACKEND_GENERATOR_URL: http://node-backend-generator:3015
   DOTNET_BACKEND_GENERATOR_URL: http://dotnet-backend-generator:3016
+  STATIC_FRONTEND_GENERATOR_URL: http://static-frontend-generator:3017
 
 services:
   # ── PostgreSQL ──────────────────────────────────────────────
@@ -259,6 +262,30 @@ services:
     networks:
       - formsync-net
 
+  # ── Static frontend generator (Express) ───────────────────────
+  static-frontend-generator:
+    build:
+      context: .
+      dockerfile: services/static-frontend-generator/Dockerfile
+    container_name: formsync-static-frontend
+    restart: unless-stopped
+    environment:
+      <<: *common-env
+    ports:
+      - "3017:3017"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'node -e "require(''http'').get(''http://localhost:3017/health'', r => { r.statusCode === 200 ? process.exit(0) : process.exit(1) }).on(''error'', () => process.exit(1))"',
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - formsync-net
+
   # ── API Gateway (Express) ───────────────────────────────────
   api-gateway:
     build:
@@ -284,6 +311,8 @@ services:
       node-backend-generator:
         condition: service_started
       dotnet-backend-generator:
+        condition: service_started
+      static-frontend-generator:
         condition: service_started
     healthcheck:
       test:

--- a/formsync/frontend/Dockerfile
+++ b/formsync/frontend/Dockerfile
@@ -6,6 +6,14 @@ WORKDIR /workspace
 # Shared tsconfig — frontend/tsconfig.json extends ../config/tsconfig.base.json
 COPY config/ config/
 
+# Workspace package required by file:../packages/form-types in package.json
+COPY packages/form-types ./packages/form-types
+WORKDIR /workspace/packages/form-types
+RUN npm install && npm run build
+
+# Destination paths are relative to WORKDIR — reset so COPY lands under /workspace
+WORKDIR /workspace
+
 # Install dependencies first (cache layer)
 COPY frontend/package*.json frontend/
 WORKDIR /workspace/frontend

--- a/formsync/frontend/nginx.conf
+++ b/formsync/frontend/nginx.conf
@@ -100,6 +100,17 @@ server {
         proxy_send_timeout 120s;
     }
 
+    location /static-frontend {
+        proxy_pass http://gateway;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s;
+        proxy_send_timeout 120s;
+    }
+
     location /node-backend {
         proxy_pass http://gateway;
         proxy_http_version 1.1;

--- a/formsync/frontend/package.json
+++ b/formsync/frontend/package.json
@@ -12,6 +12,7 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@formsync/form-types": "file:../packages/form-types",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/formsync/frontend/src/components/FrontendStackSelector.tsx
+++ b/formsync/frontend/src/components/FrontendStackSelector.tsx
@@ -28,7 +28,7 @@ const options: {
   {
     id: "react",
     label: "React (Vite)",
-    description: "SPA · TypeScript · component preview",
+    description: "SPA · TypeScript · exports all builder field types (files as Base64-in-JSON)",
     icon: Code2,
     color: "from-purple-500 to-blue-600",
     bgColor: "bg-purple-50 dark:bg-purple-950/30",
@@ -39,7 +39,7 @@ const options: {
   {
     id: "htmlBootstrap",
     label: "HTML + Bootstrap",
-    description: "Static files · no build step · vanilla JS",
+    description: "Static files · no build · same palette (repeaters, files, calculated, etc.)",
     icon: LayoutTemplate,
     color: "from-amber-500 to-orange-600",
     bgColor: "bg-amber-50 dark:bg-amber-950/30",

--- a/formsync/frontend/src/components/FrontendStackSelector.tsx
+++ b/formsync/frontend/src/components/FrontendStackSelector.tsx
@@ -1,0 +1,105 @@
+/**
+ * Frontend stack for fullstack ZIP — mirrors BackendLanguageSelector layout.
+ */
+
+import React from "react";
+import { Code2, LayoutTemplate } from "lucide-react";
+import { motion } from "framer-motion";
+import { cn } from "@/lib/utils";
+import type { FrontendStack } from "@/services/generationService";
+
+interface FrontendStackSelectorProps {
+  selected: FrontendStack;
+  onChange: (stack: FrontendStack) => void;
+  className?: string;
+}
+
+const options: {
+  id: FrontendStack;
+  label: string;
+  description: string;
+  icon: typeof Code2 | typeof LayoutTemplate;
+  color: string;
+  bgColor: string;
+  borderColor: string;
+  hoverBorderColor: string;
+  textColor: string;
+}[] = [
+  {
+    id: "react",
+    label: "React (Vite)",
+    description: "SPA · TypeScript · component preview",
+    icon: Code2,
+    color: "from-purple-500 to-blue-600",
+    bgColor: "bg-purple-50 dark:bg-purple-950/30",
+    borderColor: "border-purple-500",
+    hoverBorderColor: "hover:border-purple-300 dark:hover:border-purple-600",
+    textColor: "text-purple-800 dark:text-purple-300",
+  },
+  {
+    id: "htmlBootstrap",
+    label: "HTML + Bootstrap",
+    description: "Static files · no build step · vanilla JS",
+    icon: LayoutTemplate,
+    color: "from-amber-500 to-orange-600",
+    bgColor: "bg-amber-50 dark:bg-amber-950/30",
+    borderColor: "border-amber-500",
+    hoverBorderColor: "hover:border-amber-300 dark:hover:border-amber-600",
+    textColor: "text-amber-800 dark:text-amber-300",
+  },
+];
+
+export const FrontendStackSelector: React.FC<FrontendStackSelectorProps> = ({
+  selected,
+  onChange,
+  className,
+}) => {
+  return (
+    <div
+      className={cn("grid w-full grid-cols-1 gap-2 sm:grid-cols-2 sm:gap-3", className)}
+      role="radiogroup"
+      aria-label="Frontend generation stack"
+    >
+      {options.map((opt) => {
+        const Icon = opt.icon;
+        const isSelected = selected === opt.id;
+
+        return (
+          <motion.button
+            key={opt.id}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            onClick={() => onChange(opt.id)}
+            whileHover={{ scale: 1.01 }}
+            whileTap={{ scale: 0.99 }}
+            className={cn(
+              "relative flex flex-col items-start gap-2 rounded-xl border-2 p-4 text-left transition-colors",
+              opt.bgColor,
+              isSelected ? opt.borderColor : "border-transparent",
+              opt.hoverBorderColor,
+            )}
+          >
+            <div
+              className={cn(
+                "flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-br text-white shadow-sm",
+                opt.color,
+              )}
+            >
+              <Icon className="h-5 w-5" />
+            </div>
+            <div>
+              <div className={cn("font-semibold", opt.textColor)}>{opt.label}</div>
+              <p className="text-xs text-neutral-600 dark:text-neutral-400">
+                {opt.description}
+              </p>
+            </div>
+            {isSelected && (
+              <span className="absolute right-3 top-3 h-2 w-2 rounded-full bg-current opacity-80" />
+            )}
+          </motion.button>
+        );
+      })}
+    </div>
+  );
+};

--- a/formsync/frontend/src/pages/GeneratedCodePage.tsx
+++ b/formsync/frontend/src/pages/GeneratedCodePage.tsx
@@ -277,6 +277,7 @@ export const GeneratedCodePage: React.FC = () => {
             setLocalState({
               generatedCode: { ...MOCK_CODE, ...result.data },
               schema: schemaData,
+              ...(stash.form && { formModel: stash.form }),
             });
             toast.success("Code generated successfully");
           } else {

--- a/formsync/frontend/src/pages/GeneratedCodePage.tsx
+++ b/formsync/frontend/src/pages/GeneratedCodePage.tsx
@@ -15,9 +15,11 @@ import { toast } from "sonner";
 import {
   generationService,
   type BackendLanguage,
+  type FrontendStack,
 } from "../services/generationService";
 import { FlowDiagram } from "../components/shared/FlowDiagram";
 import { BackendLanguageSelector } from "../components/BackendLanguageSelector";
+import { FrontendStackSelector } from "../components/FrontendStackSelector";
 import type { FormModel, JsonSchema } from "../types";
 import { FORMSYNC_BUILDER_EXPORT_FORM_KEY } from "../context/BuilderContext";
 
@@ -142,6 +144,8 @@ export const GeneratedCodePage: React.FC = () => {
     return !rs?.generatedCode;
   });
   const [isDownloadingBackend, setIsDownloadingBackend] = React.useState(false);
+  const [isDownloadingStaticFrontend, setIsDownloadingStaticFrontend] =
+    React.useState(false);
   const backendLanguageFromSession = sessionStorage.getItem(
     "formsync_backend_language",
   ) as BackendLanguage | null;
@@ -152,6 +156,14 @@ export const GeneratedCodePage: React.FC = () => {
     "springBoot";
   const [backendLanguage, setBackendLanguage] =
     React.useState<BackendLanguage>(initialBackendLanguage);
+
+  const frontendStackFromSession = sessionStorage.getItem(
+    "formsync_frontend_stack",
+  ) as FrontendStack | null;
+  const initialFrontendStack: FrontendStack =
+    frontendStackFromSession === "htmlBootstrap" ? "htmlBootstrap" : "react";
+  const [frontendStack, setFrontendStack] =
+    React.useState<FrontendStack>(initialFrontendStack);
 
   /** Tracks backendLanguage for regenerating preview only when the user changes the selector. */
   const prevBackendLanguageRef = React.useRef<BackendLanguage | null>(null);
@@ -181,16 +193,15 @@ export const GeneratedCodePage: React.FC = () => {
       if (schemaId && syncedFromBuilder) {
         setIsLoading(true);
         try {
-          const result = await generationService.generateAll(
-            syncedFromBuilder,
-            backendLanguage,
-          );
           try {
             sessionStorage.removeItem(FORMSYNC_BUILDER_EXPORT_FORM_KEY);
           } catch {
             /* ignore */
           }
-          const result = await generationService.generateAll(syncedFromBuilder);
+          const result = await generationService.generateAll(
+            syncedFromBuilder,
+            backendLanguage,
+          );
           if (result.success && result.data) {
             setLocalState({
               generatedCode: { ...MOCK_CODE, ...result.data },
@@ -222,7 +233,10 @@ export const GeneratedCodePage: React.FC = () => {
         if (stash.syncedSchema) {
           setIsLoading(true);
           try {
-            const result = await generationService.generateAll(stash.syncedSchema);
+            const result = await generationService.generateAll(
+              stash.syncedSchema,
+              backendLanguage,
+            );
             if (result.success && result.data) {
               setLocalState({
                 generatedCode: { ...MOCK_CODE, ...result.data },
@@ -263,7 +277,6 @@ export const GeneratedCodePage: React.FC = () => {
             setLocalState({
               generatedCode: { ...MOCK_CODE, ...result.data },
               schema: schemaData,
-              ...(formModelFromExport && { formModel: formModelFromExport }),
             });
             toast.success("Code generated successfully");
           } else {
@@ -360,10 +373,12 @@ export const GeneratedCodePage: React.FC = () => {
     setIsDownloadingBackend(true);
     try {
       sessionStorage.setItem("formsync_backend_language", backendLanguage);
+      sessionStorage.setItem("formsync_frontend_stack", frontendStack);
       await generationService.downloadFullstackZip(
         state.formModel,
         state.schema,
         backendLanguage,
+        frontendStack,
       );
       toast.success("Fullstack project downloaded successfully!");
     } catch (error: any) {
@@ -371,6 +386,25 @@ export const GeneratedCodePage: React.FC = () => {
       toast.error(error.message || "Failed to download fullstack project");
     } finally {
       setIsDownloadingBackend(false);
+    }
+  };
+
+  const handleDownloadStaticFrontendOnly = async () => {
+    if (!state.formModel) {
+      toast.error(
+        "Open this page from the Form Builder with your form to download the HTML frontend.",
+      );
+      return;
+    }
+    setIsDownloadingStaticFrontend(true);
+    try {
+      await generationService.downloadStaticFrontendZip(state.formModel);
+      toast.success("Static HTML frontend downloaded!");
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "Download failed";
+      toast.error(message);
+    } finally {
+      setIsDownloadingStaticFrontend(false);
     }
   };
 
@@ -402,20 +436,47 @@ export const GeneratedCodePage: React.FC = () => {
               Your complete application code is ready! Review, copy, or
               download.
             </p>
-            <div className="mt-4 max-w-3xl">
-              <label className="block text-xs font-bold uppercase tracking-widest text-neutral-800 dark:text-neutral-500 mb-2">
-                Backend Language
-              </label>
-              <BackendLanguageSelector
-                selected={backendLanguage}
-                onChange={(selected) => {
-                  setBackendLanguage(selected);
-                  sessionStorage.setItem(
-                    "formsync_backend_language",
-                    selected,
-                  );
-                }}
-              />
+            <div className="mt-4 max-w-3xl space-y-6">
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-widest text-neutral-800 dark:text-neutral-500 mb-2">
+                  Backend Language
+                </label>
+                <BackendLanguageSelector
+                  selected={backendLanguage}
+                  onChange={(selected) => {
+                    setBackendLanguage(selected);
+                    sessionStorage.setItem(
+                      "formsync_backend_language",
+                      selected,
+                    );
+                  }}
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-widest text-neutral-800 dark:text-neutral-500 mb-2">
+                  Frontend Stack
+                </label>
+                <FrontendStackSelector
+                  selected={frontendStack}
+                  onChange={(stack) => {
+                    setFrontendStack(stack);
+                    sessionStorage.setItem("formsync_frontend_stack", stack);
+                  }}
+                />
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={isDownloadingStaticFrontend}
+                  onClick={() => void handleDownloadStaticFrontendOnly()}
+                >
+                  {isDownloadingStaticFrontend
+                    ? "Downloading…"
+                    : "Download HTML frontend only"}
+                </Button>
+              </div>
             </div>
           </div>
 

--- a/formsync/frontend/src/services/generationService.ts
+++ b/formsync/frontend/src/services/generationService.ts
@@ -6,6 +6,8 @@
 
 export type BackendLanguage = "nodeExpress" | "springBoot" | "dotnetWebApi";
 
+export type FrontendStack = "react" | "htmlBootstrap";
+
 export interface GenerateRequest {
   schema: any;
   validatedSchema?: any;
@@ -146,13 +148,19 @@ export const generationService = {
     formModel: any | undefined,
     schema: any,
     backendLanguage: BackendLanguage = "springBoot",
+    frontendStack: FrontendStack = "react",
   ): Promise<void> {
     const response = await fetch(
       `${API_GATEWAY_URL}/bundle/generate-fullstack`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ formModel, schema, backendLanguage }),
+        body: JSON.stringify({
+          formModel,
+          schema,
+          backendLanguage,
+          frontendStack,
+        }),
       },
     );
 
@@ -174,8 +182,41 @@ export const generationService = {
     const schemaSlug = String(schemaTitle)
       .toLowerCase()
       .replace(/\s+/g, "-");
-    const frontendSlug = "react";
+    const frontendSlug =
+      frontendStack === "htmlBootstrap" ? "html-bootstrap" : "react";
     a.download = `${schemaSlug}_fullstack-${frontendSlug}_${backendLanguage}.zip`;
+    document.body.appendChild(a);
+    a.click();
+    URL.revokeObjectURL(url);
+    document.body.removeChild(a);
+  },
+
+  /**
+   * Download static HTML + Bootstrap + JS only (ZIP), requires FormModel from builder.
+   */
+  async downloadStaticFrontendZip(formModel: any): Promise<void> {
+    const response = await fetch(`${API_GATEWAY_URL}/static-frontend/generate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ formModel, preview: false }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({}));
+      throw new Error(
+        errorBody?.error ||
+          `Static frontend generation failed (${response.status})`,
+      );
+    }
+
+    const blob = await response.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    const slug = String(formModel?.name || "form")
+      .toLowerCase()
+      .replace(/\s+/g, "-");
+    a.download = `${slug}-html-bootstrap.zip`;
     document.body.appendChild(a);
     a.click();
     URL.revokeObjectURL(url);

--- a/formsync/frontend/src/types/index.ts
+++ b/formsync/frontend/src/types/index.ts
@@ -1,182 +1,35 @@
 /**
- * Local type definitions for schema-ui.
- *
- * Inlined from packages/formgen-core so this app has zero shared-package coupling.
+ * Schema-ui types: canonical FormModel from @formsync/form-types; JSON Schema adapters stay local.
  */
 
-export type FieldType =
-  | 'text'
-  | 'email'
-  | 'password'
-  | 'number'
-  | 'select'
-  | 'checkbox'
-  | 'textarea'
-  | 'date'
-  | 'group'
-  // ── Advanced field types ──────────────────────────────────────────────────
-  | 'file'        // File / image upload with accept + size constraints
-  | 'richtext'    // WYSIWYG / rich-text editor
-  | 'signature'   // Canvas-based signature pad
-  | 'repeater'    // Dynamic array of child field groups
-  | 'typeahead'   // Async-loaded select (fetches from an API URL)
-  | 'calculated'  // Read-only derived value using an x-calc formula
-  | 'unknown';
+export type {
+  FieldType,
+  FieldModel,
+  FieldConstraints,
+  FieldUIConfig,
+  FieldXUI,
+  AsyncSourceConfig,
+  FieldConditions,
+  ConditionRule,
+  ConditionOperator,
+  FieldStyleOverrides,
+  ThemeColors,
+  ThemeConfig,
+  LayoutConfig,
+  FormStep,
+  SubmitConfig,
+  FormModel,
+} from "@formsync/form-types";
 
-// ─── Condition Rule ──────────────────────────────────────────────────────────
-// Used by x-conditions to show/hide a field based on other field values.
-
-export type ConditionOperator = 'eq' | 'neq' | 'gt' | 'lt' | 'gte' | 'lte' | 'contains' | 'in' | 'notEmpty';
-
-export interface ConditionRule {
-  /** The key of the source field whose value is to be checked */
-  fieldKey: string;
-  operator: ConditionOperator;
-  /** The value to compare against (not used for notEmpty) */
-  value?: string | number | boolean | string[];
-}
-
-/** All rules must pass (AND logic). Use nested groups for OR via separate conditions. */
-export interface FieldConditions {
-  rules: ConditionRule[];
-  /** Default visibility when conditions cannot be evaluated (e.g. preview mode) */
-  defaultVisible?: boolean;
-}
-
-export interface FieldConstraints {
-  min?: number;
-  max?: number;
-  minLength?: number;
-  maxLength?: number;
-  pattern?: string;
-  enum?: string[];
-  [key: string]: string | number | boolean | string[] | undefined;
-}
-
-export interface FieldStyleOverrides {
-  labelColor?: string;
-  inputTextColor?: string;
-  borderColor?: string;
-  backgroundColor?: string;
-  focusColor?: string;
-}
-
-// ─── Advanced UI config extensions ─────────────────────────────────────────
-
-/** Typeahead async source configuration */
-export interface AsyncSourceConfig {
-  /** The API URL to call. Use `{query}` as a placeholder for the search term. */
-  url: string;
-  /** Milliseconds to wait after keypress before fetching (default: 300) */
-  debounceMs?: number;
-  /** JSON path within the response array to use as the option label (default: 'label') */
-  labelPath?: string;
-  /** JSON path within the response array to use as the option value (default: 'value') */
-  valuePath?: string;
-}
-
-/** Grid + advanced UI settings stored under x-ui namespace */
-export interface FieldXUI {
-  /** Column span in a 12-column grid (1–12, default: 12) */
-  colSpan?: number;
-  /** Config for typeahead / async dropdown fields */
-  asyncSource?: AsyncSourceConfig;
-  /** For file fields: comma-separated MIME types or extensions (e.g. 'image/*,.pdf') */
-  accept?: string;
-  /** For file fields: maximum file size in bytes */
-  maxFileSizeBytes?: number;
-  /** For file fields: allow multiple file selection */
-  multiple?: boolean;
-}
-
-export interface FieldUIConfig {
-  placeholder?: string;
-  helpText?: string;
-  hidden?: boolean;
-  disabled?: boolean;
-  style?: Record<string, string | number>;
-  styleOverrides?: FieldStyleOverrides;
-  /** x-conditions: conditional visibility rules for this field */
-  'x-conditions'?: FieldConditions;
-  /** x-ui: advanced grid and type-specific UI configuration */
-  'x-ui'?: FieldXUI;
-  [key: string]: unknown;
-}
-
-export interface FieldModel {
-  id: string;
-  key: string;
-  type: FieldType;
-  label: string;
-  required: boolean;
-  defaultValue?: string | number | boolean | null;
-  constraints?: FieldConstraints;
-  ui?: FieldUIConfig;
-  children?: FieldModel[];
-  /** x-calc: formula string for calculated fields (e.g. '{quantity} * {price}') */
-  'x-calc'?: string;
-  /** Step index this field belongs to (0-based). Undefined = not wizard-assigned */
-  stepIndex?: number;
-}
-
-export interface ThemeColors {
-  primary: string;
-  background: string;
-  surface: string;
-  text: string;
-  muted: string;
-  border: string;
-  error: string;
-  inputBackground: string;
-}
-
-export interface ThemeConfig {
-  mode: 'light' | 'dark';
-  density: 'compact' | 'normal' | 'comfortable';
-  colors: ThemeColors;
-  schemes?: {
-    light: ThemeColors;
-    dark: ThemeColors;
-  };
-  typography: {
-    fontFamily: string;
-    baseFontSize: number;
-  };
-  radius: number;
-  primaryColor?: string;
-}
-
-/** A named step in a multi-step (wizard) form */
-export interface FormStep {
-  id: string;
-  title: string;
-  description?: string;
-}
-
-export interface LayoutConfig {
-  order: string[];
-  /** Optional wizard step definitions. When present, the form renders as a multi-step wizard. */
-  steps?: FormStep[];
-}
-
-export interface SubmitConfig {
-  text: string;
-  color?: string;
-}
-
-export interface FormModel {
-  id: string;
-  name: string;
-  version: string;
-  meta?: {
-    title?: string;
-    description?: string;
-  };
-  theme: ThemeConfig;
-  layout: LayoutConfig;
-  fields: FieldModel[];
-  submit?: SubmitConfig;
-}
+import type {
+  FieldModel,
+  FieldType,
+  FormModel,
+  LayoutConfig,
+  ThemeConfig,
+  FieldConstraints,
+  FieldUIConfig,
+} from "@formsync/form-types";
 
 // ─── JSON Schema adapter ──────────────────────────────────────────────────────
 
@@ -196,47 +49,51 @@ export interface JsonSchema {
   maximum?: number;
   format?: string;
   items?: JsonSchema;
+  contentEncoding?: string;
   [key: string]: unknown;
 }
 
 function humanizeLabel(key: string): string {
   return key
-    .split('.')
+    .split(".")
     .map((part) =>
       part
-        .replace(/([A-Z])/g, ' $1')
+        .replace(/([A-Z])/g, " $1")
         .replace(/^./, (str) => str.toUpperCase())
         .trim(),
     )
-    .join(' ');
+    .join(" ");
 }
 
 function mapPropertyToField(key: string, schema: JsonSchema, isRequired: boolean): FieldModel {
-  const label = schema.title || humanizeLabel(key);
-  let type: FieldType = 'unknown';
+  const label = (schema.title as string) || humanizeLabel(key);
+  let type: FieldType = "unknown";
 
-  if (schema.enum) {
-    type = 'select';
-  } else if (schema.type === 'boolean') {
-    type = 'checkbox';
-  } else if (schema.type === 'integer' || schema.type === 'number') {
-    type = 'number';
-  } else if (schema.type === 'string') {
-    if (schema.format === 'date' || schema.format === 'date-time') type = 'date';
-    else if (schema.format === 'email') type = 'email';
-    else type = 'text';
+  const xFieldType = schema["x-field-type"] as FieldType | undefined;
+  if (xFieldType && typeof xFieldType === "string") {
+    type = xFieldType;
+  } else if (schema.enum) {
+    type = "select";
+  } else if (schema.type === "boolean") {
+    type = "checkbox";
+  } else if (schema.type === "integer" || schema.type === "number") {
+    type = "number";
+  } else if (schema.type === "string") {
+    if (schema.format === "date" || schema.format === "date-time") type = "date";
+    else if (schema.format === "email") type = "email";
+    else type = "text";
   }
 
   const constraints: FieldConstraints = {};
-  if (schema.minimum !== undefined) constraints.min = schema.minimum;
-  if (schema.maximum !== undefined) constraints.max = schema.maximum;
-  if (schema.minLength !== undefined) constraints.minLength = schema.minLength;
-  if (schema.maxLength !== undefined) constraints.maxLength = schema.maxLength;
-  if (schema.pattern !== undefined) constraints.pattern = schema.pattern;
+  if (schema.minimum !== undefined) constraints.min = schema.minimum as number;
+  if (schema.maximum !== undefined) constraints.max = schema.maximum as number;
+  if (schema.minLength !== undefined) constraints.minLength = schema.minLength as number;
+  if (schema.maxLength !== undefined) constraints.maxLength = schema.maxLength as number;
+  if (schema.pattern !== undefined) constraints.pattern = schema.pattern as string;
   if (schema.enum !== undefined) constraints.enum = schema.enum.map(String);
 
   const field: FieldModel = {
-    id: `field-${key.replace(/\./g, '-')}`,
+    id: `field-${key.replace(/\./g, "-")}`,
     key,
     type,
     label,
@@ -247,33 +104,100 @@ function mapPropertyToField(key: string, schema: JsonSchema, isRequired: boolean
 
   if (
     schema.default !== undefined &&
-    (typeof schema.default === 'string' ||
-      typeof schema.default === 'number' ||
-      typeof schema.default === 'boolean')
+    (typeof schema.default === "string" ||
+      typeof schema.default === "number" ||
+      typeof schema.default === "boolean")
   ) {
     field.defaultValue = schema.default;
+  }
+
+  const xCalc = schema["x-calc"];
+  if (typeof xCalc === "string") field["x-calc"] = xCalc;
+
+  const xUi = schema["x-ui"];
+  if (xUi && typeof xUi === "object") {
+    field.ui = { ...(field.ui ?? {}), "x-ui": xUi as NonNullable<FieldUIConfig["x-ui"]> };
+  }
+  const xCond = schema["x-conditions"];
+  if (xCond && typeof xCond === "object") {
+    field.ui = {
+      ...(field.ui ?? {}),
+      "x-conditions": xCond as NonNullable<FieldUIConfig["x-conditions"]>,
+    };
   }
 
   return field;
 }
 
-function extractFields(schema: JsonSchema, parentKey = ''): FieldModel[] {
+function extractFields(schema: JsonSchema, parentKey = ""): FieldModel[] {
   const fields: FieldModel[] = [];
   const properties = schema.properties || {};
   const currentRequiredList = schema.required || [];
 
   for (const [key, propSchema] of Object.entries(properties)) {
-    if (!propSchema || typeof propSchema !== 'object') continue;
+    if (!propSchema || typeof propSchema !== "object") continue;
 
     const compositeKey = parentKey ? `${parentKey}.${key}` : key;
     const isRequired = currentRequiredList.includes(key);
 
-    if (propSchema.type === 'object' && propSchema.properties) {
+    const xFieldType = propSchema["x-field-type"] as string | undefined;
+
+    if (propSchema.type === "array" && propSchema.items && typeof propSchema.items === "object") {
+      const items = propSchema.items as JsonSchema;
+      const itemProps = items.properties;
+      if (itemProps && typeof itemProps === "object") {
+        const children: FieldModel[] = [];
+        const itemRequired = (items.required as string[] | undefined) ?? [];
+        for (const [childKey, childSchema] of Object.entries(itemProps)) {
+          if (!childSchema || typeof childSchema !== "object") continue;
+          const childComposite = `${compositeKey}.${childKey}`;
+          const childReq = itemRequired.includes(childKey);
+          if (childSchema.type === "object" && childSchema.properties) {
+            children.push({
+              id: `field-${childComposite.replace(/\./g, "-")}`,
+              key: childComposite,
+              type: "group",
+              label: (childSchema.title as string) || humanizeLabel(childKey),
+              required: childReq,
+              children: extractFields(childSchema, childComposite),
+              ui: {},
+            });
+          } else {
+            children.push(mapPropertyToField(childComposite, childSchema, childReq));
+          }
+        }
+        fields.push({
+          id: `field-${compositeKey.replace(/\./g, "-")}`,
+          key: compositeKey,
+          type: "repeater",
+          label: (propSchema.title as string) || humanizeLabel(key),
+          required: isRequired,
+          children,
+          ui: {},
+        });
+        continue;
+      }
+    }
+
+    if (propSchema.type === "object" && propSchema.properties) {
+      if (xFieldType === "repeater") {
+        const children = extractFields(propSchema, compositeKey);
+        fields.push({
+          id: `field-${compositeKey.replace(/\./g, "-")}`,
+          key: compositeKey,
+          type: "repeater",
+          label: (propSchema.title as string) || humanizeLabel(key),
+          required: isRequired,
+          children,
+          ui: {},
+        });
+        continue;
+      }
       fields.push({
-        id: `field-${compositeKey.replace(/\./g, '-')}`,
+        id: `field-${compositeKey.replace(/\./g, "-")}`,
         key: compositeKey,
-        type: 'group',
-        label: propSchema.title || humanizeLabel(key),
+        type: "group",
+        label: (propSchema.title as string) || humanizeLabel(key),
         required: isRequired,
         children: extractFields(propSchema, compositeKey),
         ui: {},
@@ -290,31 +214,31 @@ export function parseJsonSchemaToFormModel(schema: JsonSchema): FormModel {
   const fields = extractFields(schema);
   const layout: LayoutConfig = { order: fields.map((f) => f.id) };
   const theme: ThemeConfig = {
-    mode: 'light',
-    density: 'normal',
+    mode: "light",
+    density: "normal",
     radius: 4,
     colors: {
-      primary: '#000000',
-      background: '#ffffff',
-      surface: '#ffffff',
-      text: '#111827',
-      muted: '#6b7280',
-      border: '#e5e7eb',
-      error: '#ef4444',
-      inputBackground: '#ffffff',
+      primary: "#000000",
+      background: "#ffffff",
+      surface: "#ffffff",
+      text: "#111827",
+      muted: "#6b7280",
+      border: "#e5e7eb",
+      error: "#ef4444",
+      inputBackground: "#ffffff",
     },
-    typography: { fontFamily: 'Inter, sans-serif', baseFontSize: 16 },
+    typography: { fontFamily: "Inter, sans-serif", baseFontSize: 16 },
   };
 
   return {
-    id: schema.$id || 'form-' + Date.now().toString(36),
-    name: schema.title || 'Untitled Form',
-    version: '1.0.0',
+    id: schema.$id || "form-" + Date.now().toString(36),
+    name: schema.title || "Untitled Form",
+    version: "1.0.0",
     meta: { title: schema.title, description: schema.description },
     theme,
     layout,
     fields,
-    submit: { text: 'Submit' },
+    submit: { text: "Submit" },
   };
 }
 
@@ -322,8 +246,8 @@ export function parseJsonSchemaToFormModel(schema: JsonSchema): FormModel {
 
 /** Top-level JSON Schema property name for a root field key (first segment only). */
 function topLevelPropertyKey(field: FieldModel): string {
-  if (!field.key.includes('.')) return field.key;
-  return field.key.split('.')[0]!;
+  if (!field.key.includes(".")) return field.key;
+  return field.key.split(".")[0]!;
 }
 
 function leafFieldToJsonSchema(field: FieldModel): JsonSchema {
@@ -334,47 +258,57 @@ function leafFieldToJsonSchema(field: FieldModel): JsonSchema {
   }
 
   switch (field.type) {
-    case 'checkbox':
-      prop.type = 'boolean';
+    case "checkbox":
+      prop.type = "boolean";
       break;
-    case 'number':
-      prop.type = 'number';
+    case "number":
+      prop.type = "number";
       if (field.constraints?.min !== undefined) prop.minimum = field.constraints.min;
       if (field.constraints?.max !== undefined) prop.maximum = field.constraints.max;
       break;
-    case 'select':
-      prop.type = 'string';
+    case "select":
+      prop.type = "string";
       if (field.constraints?.enum?.length) {
         prop.enum = field.constraints.enum.map((e) => e as string | number);
       }
       break;
-    case 'date':
-      prop.type = 'string';
-      prop.format = 'date';
+    case "date":
+      prop.type = "string";
+      prop.format = "date";
       break;
-    case 'email':
-      prop.type = 'string';
-      prop.format = 'email';
+    case "email":
+      prop.type = "string";
+      prop.format = "email";
       break;
-    case 'password':
-      prop.type = 'string';
-      prop.format = 'password';
+    case "password":
+      prop.type = "string";
+      prop.format = "password";
       break;
-    case 'textarea':
-      prop.type = 'string';
+    case "textarea":
+      prop.type = "string";
       break;
-    case 'file':
-    case 'richtext':
-    case 'signature':
-    case 'typeahead':
-    case 'calculated':
-    case 'repeater':
-    case 'unknown':
-      prop.type = 'string';
-      prop['x-field-type'] = field.type;
+    case "file":
+      prop.type = "string";
+      prop.contentEncoding = "base64";
+      prop["x-field-type"] = "file";
+      break;
+    case "richtext":
+    case "signature":
+    case "typeahead":
+    case "calculated":
+      prop.type = "string";
+      prop["x-field-type"] = field.type;
+      break;
+    case "repeater":
+      prop.type = "string";
+      prop["x-field-type"] = "repeater";
+      break;
+    case "unknown":
+      prop.type = "string";
+      prop["x-field-type"] = "unknown";
       break;
     default:
-      prop.type = 'string';
+      prop.type = "string";
   }
 
   if (field.constraints?.minLength !== undefined) prop.minLength = field.constraints.minLength;
@@ -383,17 +317,17 @@ function leafFieldToJsonSchema(field: FieldModel): JsonSchema {
 
   if (
     field.defaultValue !== undefined &&
-    (typeof field.defaultValue === 'string' ||
-      typeof field.defaultValue === 'number' ||
-      typeof field.defaultValue === 'boolean')
+    (typeof field.defaultValue === "string" ||
+      typeof field.defaultValue === "number" ||
+      typeof field.defaultValue === "boolean")
   ) {
     prop.default = field.defaultValue;
   }
 
   const ui = field.ui;
-  if (ui?.['x-conditions']) prop['x-conditions'] = ui['x-conditions'];
-  if (ui?.['x-ui']) prop['x-ui'] = ui['x-ui'];
-  if (field['x-calc']) prop['x-calc'] = field['x-calc'];
+  if (ui?.["x-conditions"]) prop["x-conditions"] = ui["x-conditions"];
+  if (ui?.["x-ui"]) prop["x-ui"] = ui["x-ui"];
+  if (field["x-calc"]) prop["x-calc"] = field["x-calc"];
 
   return prop;
 }
@@ -404,15 +338,15 @@ function groupFieldToJsonSchema(field: FieldModel): JsonSchema {
   const required: string[] = [];
 
   for (const child of field.children ?? []) {
-    const rel = child.key.startsWith(parentKey + '.')
-      ? child.key.slice(parentKey.length + 1)
-      : child.key;
-    const propName = rel.includes('.') ? rel.split('.')[0]! : rel;
+    const rel = child.key.startsWith(parentKey + ".") ? child.key.slice(parentKey.length + 1) : child.key;
+    const propName = rel.includes(".") ? rel.split(".")[0]! : rel;
 
     if (properties[propName]) continue;
 
-    if (child.type === 'group') {
+    if (child.type === "group") {
       properties[propName] = groupFieldToJsonSchema(child);
+    } else if (child.type === "repeater") {
+      properties[propName] = repeaterFieldToJsonSchema(child);
     } else {
       properties[propName] = leafFieldToJsonSchema(child);
     }
@@ -423,7 +357,7 @@ function groupFieldToJsonSchema(field: FieldModel): JsonSchema {
   }
 
   const schema: JsonSchema = {
-    type: 'object',
+    type: "object",
     title: field.label,
     properties,
   };
@@ -436,14 +370,54 @@ function groupFieldToJsonSchema(field: FieldModel): JsonSchema {
   return schema;
 }
 
+/** Build JSON Schema for a repeater: array of objects from children (same nesting rules as group items). */
+function repeaterFieldToJsonSchema(field: FieldModel): JsonSchema {
+  const parentKey = field.key;
+  const properties: Record<string, JsonSchema> = {};
+  const required: string[] = [];
+
+  for (const child of field.children ?? []) {
+    const rel = child.key.startsWith(parentKey + ".") ? child.key.slice(parentKey.length + 1) : child.key;
+    const propName = rel.includes(".") ? rel.split(".")[0]! : rel;
+
+    if (properties[propName]) continue;
+
+    if (child.type === "group") {
+      properties[propName] = groupFieldToJsonSchema(child);
+    } else if (child.type === "repeater") {
+      properties[propName] = repeaterFieldToJsonSchema(child);
+    } else {
+      properties[propName] = leafFieldToJsonSchema(child);
+    }
+
+    if (child.required) {
+      required.push(propName);
+    }
+  }
+
+  const items: JsonSchema = {
+    type: "object",
+    properties,
+  };
+  const uniq = [...new Set(required)];
+  if (uniq.length > 0) {
+    items.required = uniq;
+  }
+
+  return {
+    type: "array",
+    title: field.label,
+    items,
+    "x-field-type": "repeater",
+  };
+}
+
 /**
  * Serializes the builder FormModel to JSON Schema, optionally merging onto a loaded base
  * so extensions like `$schema` and `x-formsync-metadata` are preserved.
  */
 export function formModelToJsonSchema(form: FormModel, base?: JsonSchema): JsonSchema {
-  const merged: JsonSchema = base
-    ? ({ ...base } as JsonSchema)
-    : { $schema: 'http://json-schema.org/draft-07/schema#' };
+  const merged: JsonSchema = base ? ({ ...base } as JsonSchema) : { $schema: "http://json-schema.org/draft-07/schema#" };
 
   const properties: Record<string, JsonSchema> = {};
   const required: string[] = [];
@@ -456,8 +430,10 @@ export function formModelToJsonSchema(form: FormModel, base?: JsonSchema): JsonS
     const propKey = topLevelPropertyKey(field);
     if (properties[propKey]) continue;
 
-    if (field.type === 'group') {
+    if (field.type === "group") {
       properties[propKey] = groupFieldToJsonSchema(field);
+    } else if (field.type === "repeater") {
+      properties[propKey] = repeaterFieldToJsonSchema(field);
     } else {
       properties[propKey] = leafFieldToJsonSchema(field);
     }
@@ -467,7 +443,7 @@ export function formModelToJsonSchema(form: FormModel, base?: JsonSchema): JsonS
     }
   }
 
-  merged.type = 'object';
+  merged.type = "object";
   merged.title = form.meta?.title ?? form.name;
   if (form.meta?.description !== undefined) {
     merged.description = form.meta.description;
@@ -492,12 +468,12 @@ export function validateBuilderJsonSchema(schema: unknown): BuilderJsonSchemaVal
   const errors: string[] = [];
 
   function checkObjectSchema(obj: Record<string, unknown>, path: string): void {
-    if (obj.type !== undefined && obj.type !== 'object') {
+    if (obj.type !== undefined && obj.type !== "object") {
       errors.push(`${path}: object schemas must have type "object"`);
     }
 
     const props = obj.properties;
-    if (!props || typeof props !== 'object' || Array.isArray(props)) {
+    if (!props || typeof props !== "object" || Array.isArray(props)) {
       errors.push(`${path}.properties must be an object`);
       return;
     }
@@ -509,7 +485,7 @@ export function validateBuilderJsonSchema(schema: unknown): BuilderJsonSchemaVal
       } else {
         const keys = Object.keys(props as Record<string, unknown>);
         for (const entry of req) {
-          if (typeof entry !== 'string') {
+          if (typeof entry !== "string") {
             errors.push(`${path}.required entries must be strings`);
           } else if (!keys.includes(entry)) {
             errors.push(`${path}.required references unknown property "${entry}"`);
@@ -519,23 +495,29 @@ export function validateBuilderJsonSchema(schema: unknown): BuilderJsonSchemaVal
     }
 
     for (const [key, val] of Object.entries(props)) {
-      if (!val || typeof val !== 'object' || Array.isArray(val)) {
+      if (!val || typeof val !== "object" || Array.isArray(val)) {
         errors.push(`${path}.properties["${key}"] must be an object`);
         continue;
       }
       const sub = val as Record<string, unknown>;
-      if (sub.type === 'object' && sub.properties) {
+      if (sub.type === "object" && sub.properties) {
         checkObjectSchema(sub as Record<string, unknown>, `${path}.properties["${key}"]`);
+      }
+      if (sub.type === "array" && sub.items && typeof sub.items === "object" && !Array.isArray(sub.items)) {
+        const items = sub.items as Record<string, unknown>;
+        if (items.type === "object" && items.properties) {
+          checkObjectSchema(items as Record<string, unknown>, `${path}.properties["${key}"].items`);
+        }
       }
     }
   }
 
-  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
-    errors.push('$: schema must be an object');
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    errors.push("$: schema must be an object");
     return { valid: false, errors };
   }
 
-  checkObjectSchema(schema as Record<string, unknown>, '$');
+  checkObjectSchema(schema as Record<string, unknown>, "$");
 
   return { valid: errors.length === 0, errors };
 }

--- a/formsync/frontend/vite.config.ts
+++ b/formsync/frontend/vite.config.ts
@@ -54,6 +54,10 @@ export default defineConfig({
         target: "http://localhost:3000",
         changeOrigin: true,
       },
+      "/static-frontend": {
+        target: "http://localhost:3000",
+        changeOrigin: true,
+      },
       "/node-backend": {
         target: "http://localhost:3000",
         changeOrigin: true,

--- a/formsync/package-lock.json
+++ b/formsync/package-lock.json
@@ -8,6 +8,7 @@
       "name": "formsync",
       "version": "1.0.0",
       "workspaces": [
+        "packages/formgen-shared",
         "services/api-gateway",
         "services/schema-enhancement-engine",
         "services/user-management-service",
@@ -15,6 +16,7 @@
         "services/schema-openapi",
         "services/runtime-binding-engine",
         "services/formgen-service",
+        "services/static-frontend-generator",
         "services/node-backend-generator",
         "services/dotnet-backend-generator",
         "frontend"
@@ -1798,6 +1800,10 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@formsync/formgen-shared": {
+      "resolved": "packages/formgen-shared",
+      "link": true
     },
     "node_modules/@formsync/schema-openapi": {
       "resolved": "services/schema-openapi",
@@ -15769,6 +15775,10 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/static-frontend-generator": {
+      "resolved": "services/static-frontend-generator",
+      "link": true
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -18015,6 +18025,14 @@
       "name": "@formsync/formgen-core",
       "version": "0.0.1",
       "extraneous": true
+    },
+    "packages/formgen-shared": {
+      "name": "@formsync/formgen-shared",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/node": "^20.10.5",
+        "typescript": "^5.2.2"
+      }
     },
     "packages/plugins": {
       "name": "@formsync/plugins",
@@ -20333,6 +20351,7 @@
     "services/formgen-service": {
       "version": "1.0.0",
       "dependencies": {
+        "@formsync/formgen-shared": "file:../../packages/formgen-shared",
         "archiver": "^7.0.1",
         "axios": "^1.13.2",
         "body-parser": "^2.2.1",
@@ -24367,6 +24386,535 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "services/static-frontend-generator": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@formsync/formgen-shared": "file:../../packages/formgen-shared",
+        "archiver": "^7.0.1",
+        "cors": "^2.8.5",
+        "dotenv": "^16.3.1",
+        "express": "^5.2.1",
+        "fs-extra": "^11.3.3"
+      },
+      "devDependencies": {
+        "@types/archiver": "^7.0.0",
+        "@types/cors": "^2.8.19",
+        "@types/express": "^5.0.6",
+        "@types/fs-extra": "^11.0.4",
+        "@types/node": "^20.10.5",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.2.2"
+      }
+    },
+    "services/static-frontend-generator/node_modules/@types/archiver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-7.0.0.tgz",
+      "integrity": "sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
+    },
+    "services/static-frontend-generator/node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "services/static-frontend-generator/node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "services/static-frontend-generator/node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "services/static-frontend-generator/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "services/static-frontend-generator/node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "services/static-frontend-generator/node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "services/static-frontend-generator/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "services/static-frontend-generator/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "services/static-frontend-generator/node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "services/static-frontend-generator/node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "services/static-frontend-generator/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "services/static-frontend-generator/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "services/static-frontend-generator/node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "services/static-frontend-generator/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "services/static-frontend-generator/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "services/static-frontend-generator/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "services/static-frontend-generator/node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "services/static-frontend-generator/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "services/static-frontend-generator/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "services/static-frontend-generator/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "services/static-frontend-generator/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "services/static-frontend-generator/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "services/static-frontend-generator/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "services/static-frontend-generator/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "services/static-frontend-generator/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "services/static-frontend-generator/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "services/static-frontend-generator/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "services/static-frontend-generator/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "services/static-frontend-generator/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "services/static-frontend-generator/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "services/static-frontend-generator/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "services/static-frontend-generator/node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "services/user-management-service": {

--- a/formsync/package-lock.json
+++ b/formsync/package-lock.json
@@ -8,6 +8,7 @@
       "name": "formsync",
       "version": "1.0.0",
       "workspaces": [
+        "packages/form-types",
         "packages/formgen-shared",
         "services/api-gateway",
         "services/schema-enhancement-engine",
@@ -355,6 +356,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@formsync/form-types": "file:../packages/form-types",
         "@monaco-editor/react": "^4.6.0",
         "@radix-ui/react-alert-dialog": "^1.0.5",
         "@radix-ui/react-dialog": "^1.0.5",
@@ -1800,6 +1802,10 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@formsync/form-types": {
+      "resolved": "packages/form-types",
+      "link": true
     },
     "node_modules/@formsync/formgen-shared": {
       "resolved": "packages/formgen-shared",
@@ -18021,6 +18027,13 @@
         }
       }
     },
+    "packages/form-types": {
+      "name": "@formsync/form-types",
+      "version": "1.0.0",
+      "devDependencies": {
+        "typescript": "^5.2.2"
+      }
+    },
     "packages/formgen-core": {
       "name": "@formsync/formgen-core",
       "version": "0.0.1",
@@ -20351,6 +20364,7 @@
     "services/formgen-service": {
       "version": "1.0.0",
       "dependencies": {
+        "@formsync/form-types": "file:../../packages/form-types",
         "@formsync/formgen-shared": "file:../../packages/formgen-shared",
         "archiver": "^7.0.1",
         "axios": "^1.13.2",
@@ -24391,6 +24405,7 @@
     "services/static-frontend-generator": {
       "version": "1.0.0",
       "dependencies": {
+        "@formsync/form-types": "file:../../packages/form-types",
         "@formsync/formgen-shared": "file:../../packages/formgen-shared",
         "archiver": "^7.0.1",
         "cors": "^2.8.5",

--- a/formsync/package.json
+++ b/formsync/package.json
@@ -4,6 +4,7 @@
   "description": "FormSync Component 1 - Intelligent Schema Definition & AI Integration",
   "private": true,
   "workspaces": [
+    "packages/form-types",
     "packages/formgen-shared",
     "services/api-gateway",
     "services/schema-enhancement-engine",

--- a/formsync/package.json
+++ b/formsync/package.json
@@ -4,6 +4,7 @@
   "description": "FormSync Component 1 - Intelligent Schema Definition & AI Integration",
   "private": true,
   "workspaces": [
+    "packages/formgen-shared",
     "services/api-gateway",
     "services/schema-enhancement-engine",
     "services/user-management-service",
@@ -11,6 +12,7 @@
     "services/schema-openapi",
     "services/runtime-binding-engine",
     "services/formgen-service",
+    "services/static-frontend-generator",
     "services/node-backend-generator",
     "services/dotnet-backend-generator",
     "frontend"
@@ -22,6 +24,7 @@
     "dev:backend-gen": "npm run dev --workspace=backend-dto-generator",
     "dev:runtime": "npm run dev --workspace=runtime-binding-engine",
     "dev:formgen": "npm run dev --workspace=formgen-service",
+    "dev:static-frontend": "npm run dev --workspace=static-frontend-generator",
     "dev:node-backend": "npm run dev --workspace=node-backend-generator",
     "dev:gateway": "npm run dev --workspace=api-gateway",
     "dev": "concurrently \"npm run dev:gateway\" \"npm run dev:schema:api\" \"npm run dev:user:api\" \"npm run dev:backend-gen\" \"npm run dev:runtime\" \"npm run dev:formgen\" \"npm run dev:node-backend\" \"npm run dev:schema:ui\"",

--- a/formsync/packages/form-types/package.json
+++ b/formsync/packages/form-types/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@formsync/form-types",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Shared FormModel / FieldModel types for FormSync builder and generators",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint \"src/**/*.ts\" --fix",
+    "format": "prettier --write \"src/**/*.ts\""
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  }
+}

--- a/formsync/packages/form-types/src/index.ts
+++ b/formsync/packages/form-types/src/index.ts
@@ -1,0 +1,159 @@
+/**
+ * Canonical FormModel types shared by frontend, formgen-service, and static-frontend-generator.
+ */
+
+export type FieldType =
+  | "text"
+  | "email"
+  | "password"
+  | "number"
+  | "select"
+  | "checkbox"
+  | "textarea"
+  | "date"
+  | "group"
+  | "file"
+  | "richtext"
+  | "signature"
+  | "repeater"
+  | "typeahead"
+  | "calculated"
+  | "unknown";
+
+export type ConditionOperator =
+  | "eq"
+  | "neq"
+  | "gt"
+  | "lt"
+  | "gte"
+  | "lte"
+  | "contains"
+  | "in"
+  | "notEmpty";
+
+export interface ConditionRule {
+  fieldKey: string;
+  operator: ConditionOperator;
+  value?: string | number | boolean | string[];
+}
+
+export interface FieldConditions {
+  rules: ConditionRule[];
+  defaultVisible?: boolean;
+}
+
+export interface FieldConstraints {
+  min?: number;
+  max?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  enum?: string[];
+  [key: string]: string | number | boolean | string[] | undefined;
+}
+
+export interface FieldStyleOverrides {
+  labelColor?: string;
+  inputTextColor?: string;
+  borderColor?: string;
+  backgroundColor?: string;
+  focusColor?: string;
+}
+
+export interface AsyncSourceConfig {
+  url: string;
+  debounceMs?: number;
+  labelPath?: string;
+  valuePath?: string;
+}
+
+export interface FieldXUI {
+  colSpan?: number;
+  asyncSource?: AsyncSourceConfig;
+  accept?: string;
+  maxFileSizeBytes?: number;
+  multiple?: boolean;
+}
+
+export interface FieldUIConfig {
+  placeholder?: string;
+  helpText?: string;
+  hidden?: boolean;
+  disabled?: boolean;
+  style?: Record<string, string | number>;
+  styleOverrides?: FieldStyleOverrides;
+  "x-conditions"?: FieldConditions;
+  "x-ui"?: FieldXUI;
+  [key: string]: unknown;
+}
+
+export interface FieldModel {
+  id: string;
+  key: string;
+  type: FieldType;
+  label: string;
+  required: boolean;
+  defaultValue?: string | number | boolean | null;
+  constraints?: FieldConstraints;
+  ui?: FieldUIConfig;
+  children?: FieldModel[];
+  "x-calc"?: string;
+  stepIndex?: number;
+}
+
+export interface ThemeColors {
+  primary: string;
+  background: string;
+  surface: string;
+  text: string;
+  muted: string;
+  border: string;
+  error: string;
+  inputBackground: string;
+}
+
+export interface ThemeConfig {
+  mode: "light" | "dark";
+  density: "compact" | "normal" | "comfortable";
+  colors: ThemeColors;
+  schemes?: {
+    light: ThemeColors;
+    dark: ThemeColors;
+  };
+  typography: {
+    fontFamily: string;
+    baseFontSize: number;
+  };
+  radius: number;
+  primaryColor?: string;
+}
+
+export interface FormStep {
+  id: string;
+  title: string;
+  description?: string;
+}
+
+export interface LayoutConfig {
+  order: string[];
+  steps?: FormStep[];
+}
+
+export interface SubmitConfig {
+  text: string;
+  color?: string;
+}
+
+export interface FormModel {
+  id: string;
+  name: string;
+  version: string;
+  meta?: {
+    title?: string;
+    description?: string;
+  };
+  theme: ThemeConfig;
+  layout: LayoutConfig;
+  fields: FieldModel[];
+  submit?: SubmitConfig;
+}

--- a/formsync/packages/form-types/tsconfig.json
+++ b/formsync/packages/form-types/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/formsync/packages/formgen-shared/package.json
+++ b/formsync/packages/formgen-shared/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@formsync/formgen-shared",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Shared browser submit / wire helpers for FormSync generators",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint \"src/**/*.ts\" --fix",
+    "format": "prettier --write \"src/**/*.ts\""
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.5",
+    "typescript": "^5.2.2"
+  }
+}

--- a/formsync/packages/formgen-shared/src/index.ts
+++ b/formsync/packages/formgen-shared/src/index.ts
@@ -1,0 +1,9 @@
+export type { BackendLanguage } from "./types";
+export {
+  buildReactWiredSubmitReplacement,
+  type ReactWireReplacementOptions,
+} from "./react-wire";
+export {
+  buildVanillaWiredSubmitReplacement,
+  type VanillaWiredSubmitOptions,
+} from "./vanilla-submit";

--- a/formsync/packages/formgen-shared/src/react-wire.ts
+++ b/formsync/packages/formgen-shared/src/react-wire.ts
@@ -21,11 +21,17 @@ export function buildReactWiredSubmitReplacement(
       const API_PATH = import.meta.env.VITE_API_PATH || "${apiPathEscaped}";
       const FIELD_TYPES: Record<string, string> = ${opts.serializedFieldTypes};
 
+      const templatePathFromIndexedPath = (path: string) =>
+        path.split(".").filter((p) => !/^\\d+$/.test(p)).join(".");
+
+      const resolveFieldType = (path: string): string | undefined =>
+        FIELD_TYPES[path] ?? FIELD_TYPES[templatePathFromIndexedPath(path)];
+
       const setDeepValue = (target: Record<string, any>, path: string, value: any) => {
         const parts = path.split(".");
         let current: Record<string, any> = target;
         for (let i = 0; i < parts.length - 1; i++) {
-          const segment = parts[i];
+          const segment = parts[i]!;
           if (
             typeof current[segment] !== "object" ||
             current[segment] === null ||
@@ -35,7 +41,7 @@ export function buildReactWiredSubmitReplacement(
           }
           current = current[segment];
         }
-        current[parts[parts.length - 1]] = value;
+        current[parts[parts.length - 1]!] = value;
       };
 
       const coerceValue = (fieldType: string | undefined, rawValue: FormDataEntryValue) => {
@@ -52,6 +58,24 @@ export function buildReactWiredSubmitReplacement(
         return rawValue;
       };
 
+      const numericKeysToArrays = (value: unknown): unknown => {
+        if (value === null || typeof value !== "object") return value;
+        if (Array.isArray(value)) return value.map(numericKeysToArrays);
+        const obj = value as Record<string, unknown>;
+        const keys = Object.keys(obj);
+        const allNumeric =
+          keys.length > 0 && keys.every((k) => /^\\d+$/.test(k));
+        if (allNumeric) {
+          const sorted = keys.sort((a, b) => Number(a) - Number(b));
+          return sorted.map((k) => numericKeysToArrays(obj[k]));
+        }
+        const out: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(obj)) {
+          out[k] = numericKeysToArrays(v);
+        }
+        return out;
+      };
+
       const stripEmptyJsonValues = (value: unknown): unknown => {
         if (value === "" || value === null || value === undefined) return undefined;
         if (typeof value !== "object") return value;
@@ -60,9 +84,9 @@ export function buildReactWiredSubmitReplacement(
             .map(stripEmptyJsonValues)
             .filter((v) => v !== undefined);
         }
-        const obj = value as Record<string, unknown>;
+        const o = value as Record<string, unknown>;
         const out: Record<string, unknown> = {};
-        for (const [k, v] of Object.entries(obj)) {
+        for (const [k, v] of Object.entries(o)) {
           const s = stripEmptyJsonValues(v);
           if (s === undefined) continue;
           if (
@@ -78,12 +102,44 @@ export function buildReactWiredSubmitReplacement(
         return out;
       };
 
+      const readAsDataURL = (file: File) =>
+        new Promise<string>((resolve, reject) => {
+          const r = new FileReader();
+          r.onload = () => resolve(typeof r.result === "string" ? r.result : "");
+          r.onerror = () => reject(r.error);
+          r.readAsDataURL(file);
+        });
+
+      const embedFileInputsAsBase64 = async (
+        form: HTMLFormElement,
+        payload: Record<string, any>,
+      ) => {
+        const inputs = form.querySelectorAll<HTMLInputElement>('input[type="file"][name]');
+        for (const input of inputs) {
+          const name = input.name;
+          const ft = resolveFieldType(name);
+          if (ft !== "file") continue;
+          const files = input.files;
+          if (!files || files.length === 0) {
+            setDeepValue(payload, name, undefined);
+            continue;
+          }
+          if (input.multiple) {
+            const urls = await Promise.all(Array.from(files).map((f) => readAsDataURL(f)));
+            setDeepValue(payload, name, urls);
+          } else {
+            setDeepValue(payload, name, await readAsDataURL(files[0]!));
+          }
+        }
+      };
+
       const toPayload = (form: HTMLFormElement) => {
         const payload: Record<string, any> = {};
         const formData = new FormData(form);
 
         for (const [key, value] of formData.entries()) {
-          setDeepValue(payload, key, coerceValue(FIELD_TYPES[key], value));
+          if (value instanceof File) continue;
+          setDeepValue(payload, key, coerceValue(resolveFieldType(key), value));
         }
 
         const checkboxes = Array.from(
@@ -99,7 +155,9 @@ export function buildReactWiredSubmitReplacement(
       };
 
       const payload = toPayload(e.currentTarget);
-      const jsonBody = stripEmptyJsonValues(payload);
+      await embedFileInputsAsBase64(e.currentTarget, payload);
+      const withArrays = numericKeysToArrays(payload);
+      const jsonBody = stripEmptyJsonValues(withArrays);
       const response = await fetch(\`\${API_BASE_URL}\${API_PATH}\`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/formsync/packages/formgen-shared/src/react-wire.ts
+++ b/formsync/packages/formgen-shared/src/react-wire.ts
@@ -1,0 +1,120 @@
+/**
+ * Replacement body for App.tsx between FORMSYNC_API_SUBMIT markers (wired fullstack).
+ * Must stay aligned with vanilla-submit.ts fetch semantics.
+ */
+
+export interface ReactWireReplacementOptions {
+  /** Pretty-printed JSON for FIELD_TYPES object literal */
+  serializedFieldTypes: string;
+  apiPath: string;
+  backendPort: number;
+}
+
+export function buildReactWiredSubmitReplacement(
+  opts: ReactWireReplacementOptions,
+): string {
+  const apiPathEscaped = opts.apiPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `/* FORMSYNC_API_SUBMIT_START */
+    setStatusMessage('');
+    try {
+      const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:${opts.backendPort}";
+      const API_PATH = import.meta.env.VITE_API_PATH || "${apiPathEscaped}";
+      const FIELD_TYPES: Record<string, string> = ${opts.serializedFieldTypes};
+
+      const setDeepValue = (target: Record<string, any>, path: string, value: any) => {
+        const parts = path.split(".");
+        let current: Record<string, any> = target;
+        for (let i = 0; i < parts.length - 1; i++) {
+          const segment = parts[i];
+          if (
+            typeof current[segment] !== "object" ||
+            current[segment] === null ||
+            Array.isArray(current[segment])
+          ) {
+            current[segment] = {};
+          }
+          current = current[segment];
+        }
+        current[parts[parts.length - 1]] = value;
+      };
+
+      const coerceValue = (fieldType: string | undefined, rawValue: FormDataEntryValue) => {
+        if (fieldType === "number") {
+          const value = typeof rawValue === "string" ? rawValue.trim() : String(rawValue);
+          if (!value) return null;
+          const numeric = Number(value);
+          return Number.isNaN(numeric) ? null : numeric;
+        }
+        if (fieldType === "checkbox") {
+          if (typeof rawValue !== "string") return false;
+          return rawValue === "on" || rawValue === "true" || rawValue === "1";
+        }
+        return rawValue;
+      };
+
+      const stripEmptyJsonValues = (value: unknown): unknown => {
+        if (value === "" || value === null || value === undefined) return undefined;
+        if (typeof value !== "object") return value;
+        if (Array.isArray(value)) {
+          return value
+            .map(stripEmptyJsonValues)
+            .filter((v) => v !== undefined);
+        }
+        const obj = value as Record<string, unknown>;
+        const out: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(obj)) {
+          const s = stripEmptyJsonValues(v);
+          if (s === undefined) continue;
+          if (
+            typeof s === "object" &&
+            s !== null &&
+            !Array.isArray(s) &&
+            Object.keys(s as Record<string, unknown>).length === 0
+          ) {
+            continue;
+          }
+          out[k] = s;
+        }
+        return out;
+      };
+
+      const toPayload = (form: HTMLFormElement) => {
+        const payload: Record<string, any> = {};
+        const formData = new FormData(form);
+
+        for (const [key, value] of formData.entries()) {
+          setDeepValue(payload, key, coerceValue(FIELD_TYPES[key], value));
+        }
+
+        const checkboxes = Array.from(
+          form.querySelectorAll<HTMLInputElement>('input[type="checkbox"][name]'),
+        );
+        for (const checkbox of checkboxes) {
+          if (!checkbox.checked) {
+            setDeepValue(payload, checkbox.name, false);
+          }
+        }
+
+        return payload;
+      };
+
+      const payload = toPayload(e.currentTarget);
+      const jsonBody = stripEmptyJsonValues(payload);
+      const response = await fetch(\`\${API_BASE_URL}\${API_PATH}\`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(jsonBody !== undefined ? jsonBody : {}),
+      });
+
+      if (!response.ok) {
+        throw new Error(\`Submission failed (\${response.status})\`);
+      }
+
+      alert("Submitted successfully");
+      console.log("Form submitted:", jsonBody !== undefined ? jsonBody : {});
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Submission failed";
+      setStatusMessage(msg);
+    }
+    /* FORMSYNC_API_SUBMIT_END */`;
+}

--- a/formsync/packages/formgen-shared/src/types.ts
+++ b/formsync/packages/formgen-shared/src/types.ts
@@ -1,0 +1,1 @@
+export type BackendLanguage = "springBoot" | "nodeExpress" | "dotnetWebApi";

--- a/formsync/packages/formgen-shared/src/vanilla-submit.ts
+++ b/formsync/packages/formgen-shared/src/vanilla-submit.ts
@@ -1,0 +1,124 @@
+/**
+ * Generated vanilla JS for static HTML export — wired API submit (inside submit handler).
+ * Uses #form-status for errors (aria-live).
+ */
+
+export interface VanillaWiredSubmitOptions {
+  serializedFieldTypes: string;
+  apiBaseUrl: string;
+  apiPath: string;
+}
+
+export function buildVanillaWiredSubmitReplacement(
+  opts: VanillaWiredSubmitOptions,
+): string {
+  const apiBase = opts.apiBaseUrl.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  const apiPathEsc = opts.apiPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `/* FORMSYNC_API_SUBMIT_START */
+    var statusEl = document.getElementById("form-status");
+    if (statusEl) statusEl.textContent = "";
+    try {
+      var API_BASE_URL = "${apiBase}";
+      var API_PATH = "${apiPathEsc}";
+      var FIELD_TYPES = ${opts.serializedFieldTypes};
+
+      var setDeepValue = function (target, path, value) {
+        var parts = path.split(".");
+        var current = target;
+        for (var i = 0; i < parts.length - 1; i++) {
+          var segment = parts[i];
+          if (
+            typeof current[segment] !== "object" ||
+            current[segment] === null ||
+            Array.isArray(current[segment])
+          ) {
+            current[segment] = {};
+          }
+          current = current[segment];
+        }
+        current[parts[parts.length - 1]] = value;
+      };
+
+      var coerceValue = function (fieldType, rawValue) {
+        if (fieldType === "number") {
+          var value = typeof rawValue === "string" ? rawValue.trim() : String(rawValue);
+          if (!value) return null;
+          var numeric = Number(value);
+          return isNaN(numeric) ? null : numeric;
+        }
+        if (fieldType === "checkbox") {
+          if (typeof rawValue !== "string") return false;
+          return rawValue === "on" || rawValue === "true" || rawValue === "1";
+        }
+        return rawValue;
+      };
+
+      var stripEmptyJsonValues = function (value) {
+        if (value === "" || value === null || value === undefined) return undefined;
+        if (typeof value !== "object") return value;
+        if (Array.isArray(value)) {
+          return value.map(stripEmptyJsonValues).filter(function (v) {
+            return v !== undefined;
+          });
+        }
+        var obj = value;
+        var out = {};
+        for (var k in obj) {
+          if (!Object.prototype.hasOwnProperty.call(obj, k)) continue;
+          var s = stripEmptyJsonValues(obj[k]);
+          if (s === undefined) continue;
+          if (
+            typeof s === "object" &&
+            s !== null &&
+            !Array.isArray(s) &&
+            Object.keys(s).length === 0
+          ) {
+            continue;
+          }
+          out[k] = s;
+        }
+        return out;
+      };
+
+      var toPayload = function (form) {
+        var payload = {};
+        var formData = new FormData(form);
+        var it = formData.entries();
+        var step = it.next();
+        while (!step.done) {
+          var key = step.value[0];
+          var value = step.value[1];
+          setDeepValue(payload, key, coerceValue(FIELD_TYPES[key], value));
+          step = it.next();
+        }
+        var checkboxes = form.querySelectorAll('input[type="checkbox"][name]');
+        for (var i = 0; i < checkboxes.length; i++) {
+          var checkbox = checkboxes[i];
+          if (!checkbox.checked) {
+            setDeepValue(payload, checkbox.name, false);
+          }
+        }
+        return payload;
+      };
+
+      var payload = toPayload(form);
+      var jsonBody = stripEmptyJsonValues(payload);
+      var response = await fetch(API_BASE_URL + API_PATH, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(jsonBody !== undefined ? jsonBody : {}),
+      });
+
+      if (!response.ok) {
+        throw new Error("Submission failed (" + response.status + ")");
+      }
+
+      alert("Submitted successfully");
+      console.log("Form submitted:", jsonBody !== undefined ? jsonBody : {});
+    } catch (err) {
+      var msg = err && err.message ? err.message : "Submission failed";
+      var statusEl = document.getElementById("form-status");
+      if (statusEl) statusEl.textContent = msg;
+    }
+    /* FORMSYNC_API_SUBMIT_END */`;
+}

--- a/formsync/packages/formgen-shared/src/vanilla-submit.ts
+++ b/formsync/packages/formgen-shared/src/vanilla-submit.ts
@@ -22,6 +22,16 @@ export function buildVanillaWiredSubmitReplacement(
       var API_PATH = "${apiPathEsc}";
       var FIELD_TYPES = ${opts.serializedFieldTypes};
 
+      var templatePathFromIndexedPath = function (path) {
+        return path.split(".").filter(function (p) {
+          return !/^\\d+$/.test(p);
+        }).join(".");
+      };
+
+      var resolveFieldType = function (path) {
+        return FIELD_TYPES[path] || FIELD_TYPES[templatePathFromIndexedPath(path)];
+      };
+
       var setDeepValue = function (target, path, value) {
         var parts = path.split(".");
         var current = target;
@@ -53,6 +63,30 @@ export function buildVanillaWiredSubmitReplacement(
         return rawValue;
       };
 
+      var numericKeysToArrays = function (value) {
+        if (value === null || typeof value !== "object") return value;
+        if (Array.isArray(value)) return value.map(numericKeysToArrays);
+        var keys = Object.keys(value);
+        var allNumeric = keys.length > 0 && keys.every(function (k) {
+          return /^\\d+$/.test(k);
+        });
+        if (allNumeric) {
+          return keys
+            .sort(function (a, b) {
+              return Number(a) - Number(b);
+            })
+            .map(function (k) {
+              return numericKeysToArrays(value[k]);
+            });
+        }
+        var out = {};
+        for (var k in value) {
+          if (!Object.prototype.hasOwnProperty.call(value, k)) continue;
+          out[k] = numericKeysToArrays(value[k]);
+        }
+        return out;
+      };
+
       var stripEmptyJsonValues = function (value) {
         if (value === "" || value === null || value === undefined) return undefined;
         if (typeof value !== "object") return value;
@@ -80,6 +114,43 @@ export function buildVanillaWiredSubmitReplacement(
         return out;
       };
 
+      var readAsDataURL = function (file) {
+        return new Promise(function (resolve, reject) {
+          var r = new FileReader();
+          r.onload = function () {
+            resolve(typeof r.result === "string" ? r.result : "");
+          };
+          r.onerror = function () {
+            reject(r.error);
+          };
+          r.readAsDataURL(file);
+        });
+      };
+
+      var embedFileInputsAsBase64 = async function (form, payload) {
+        var inputs = form.querySelectorAll('input[type="file"][name]');
+        for (var i = 0; i < inputs.length; i++) {
+          var input = inputs[i];
+          var name = input.name;
+          if (resolveFieldType(name) !== "file") continue;
+          var files = input.files;
+          if (!files || files.length === 0) {
+            setDeepValue(payload, name, undefined);
+            continue;
+          }
+          if (input.multiple) {
+            var urls = await Promise.all(
+              Array.prototype.map.call(files, function (f) {
+                return readAsDataURL(f);
+              }),
+            );
+            setDeepValue(payload, name, urls);
+          } else {
+            setDeepValue(payload, name, await readAsDataURL(files[0]));
+          }
+        }
+      };
+
       var toPayload = function (form) {
         var payload = {};
         var formData = new FormData(form);
@@ -88,7 +159,11 @@ export function buildVanillaWiredSubmitReplacement(
         while (!step.done) {
           var key = step.value[0];
           var value = step.value[1];
-          setDeepValue(payload, key, coerceValue(FIELD_TYPES[key], value));
+          if (value instanceof File) {
+            step = it.next();
+            continue;
+          }
+          setDeepValue(payload, key, coerceValue(resolveFieldType(key), value));
           step = it.next();
         }
         var checkboxes = form.querySelectorAll('input[type="checkbox"][name]');
@@ -102,7 +177,9 @@ export function buildVanillaWiredSubmitReplacement(
       };
 
       var payload = toPayload(form);
-      var jsonBody = stripEmptyJsonValues(payload);
+      await embedFileInputsAsBase64(form, payload);
+      var withArrays = numericKeysToArrays(payload);
+      var jsonBody = stripEmptyJsonValues(withArrays);
       var response = await fetch(API_BASE_URL + API_PATH, {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/formsync/packages/formgen-shared/tsconfig.json
+++ b/formsync/packages/formgen-shared/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/formsync/services/api-gateway/src/config/services.ts
+++ b/formsync/services/api-gateway/src/config/services.ts
@@ -40,7 +40,7 @@ export const SERVICES: Record<string, ServiceConfig> = {
   formgenService: {
     name: 'formgen-service',
     url: process.env.FORMGEN_SERVICE_URL || 'http://localhost:3014',
-    description: 'Generates standalone React app from FormModel',
+    description: 'React app ZIP and fullstack orchestration (React or static HTML)',
     healthPath: '/health',
   },
   nodeBackendGenerator: {
@@ -53,6 +53,12 @@ export const SERVICES: Record<string, ServiceConfig> = {
     name: 'dotnet-backend-generator',
     url: process.env.DOTNET_BACKEND_GENERATOR_URL || 'http://localhost:3016',
     description: 'Generates ASP.NET Core Web API backend from JSON Schema',
+    healthPath: '/health',
+  },
+  staticFrontendGenerator: {
+    name: 'static-frontend-generator',
+    url: process.env.STATIC_FRONTEND_GENERATOR_URL || 'http://localhost:3017',
+    description: 'Generates static HTML + Bootstrap + JavaScript from FormModel',
     healthPath: '/health',
   },
 };

--- a/formsync/services/api-gateway/src/index.ts
+++ b/formsync/services/api-gateway/src/index.ts
@@ -14,6 +14,7 @@
  *   /bundle/*          → formgen-service              (3014)  rewrite → /
  *   /node-backend/*    → node-backend-generator       (3015)  rewrite → /
  *   /dotnet-backend/*  → dotnet-backend-generator      (3016)  rewrite → /
+ *   /static-frontend/* → static-frontend-generator      (3017)  rewrite → /
  *   GET /health        → aggregate health of all services
  *   GET /              → gateway info
  */
@@ -82,6 +83,7 @@ app.get("/", (_req, res) => {
       "/bundle/*": `${SERVICES.formgenService.url} — fullstack bundle generation`,
       "/node-backend/*": `${SERVICES.nodeBackendGenerator.url} — ${SERVICES.nodeBackendGenerator.description}`,
       "/dotnet-backend/*": `${SERVICES.dotnetBackendGenerator.url} — ${SERVICES.dotnetBackendGenerator.description}`,
+      "/static-frontend/*": `${SERVICES.staticFrontendGenerator.url} — ${SERVICES.staticFrontendGenerator.description}`,
     },
     docs: {
       "schema-enhancement-engine": `${SERVICES.schemaEnhancementEngine.url}/api/docs`,
@@ -239,6 +241,14 @@ app.use(
   }),
 );
 
+// Static frontend generator  →  /static-frontend/*  rewrite to /
+app.use(
+  "/static-frontend",
+  proxy(SERVICES.staticFrontendGenerator.url, {
+    pathRewrite: { "^/static-frontend": "" },
+  }),
+);
+
 // ─── Start ────────────────────────────────────────────────────────────────────
 
 app.listen(PORT, () => {
@@ -256,6 +266,7 @@ app.listen(PORT, () => {
   console.log(`│  /bundle/*   →  formgen-service             :3014   │`);
   console.log(`│  /node-backend/* → node-backend-generator   :3015   │`);
   console.log(`│  /dotnet-backend/* → dotnet-backend-gen     :3016   │`);
+  console.log(`│  /static-frontend/* → static-frontend-gen   :3017   │`);
   console.log(`│  /health     →  aggregate health check              │`);
   console.log("└─────────────────────────────────────────────────────┘");
   console.log("");

--- a/formsync/services/formgen-service/Dockerfile
+++ b/formsync/services/formgen-service/Dockerfile
@@ -6,26 +6,28 @@ WORKDIR /workspace
 # Shared tsconfig — services extend ../../config/tsconfig.base.json
 COPY config/ config/
 
-# Install dependencies first (cache layer)
-COPY services/formgen-service/package*.json services/formgen-service/
+COPY packages/formgen-shared ./packages/formgen-shared
+WORKDIR /workspace/packages/formgen-shared
+RUN npm install && npm run build
+
 WORKDIR /workspace/services/formgen-service
+COPY services/formgen-service/package*.json ./
 RUN npm install
 
-# Copy source and build
 COPY services/formgen-service/ .
 RUN npm run build
 
 # ── Runtime stage ──────────────────────────────────────────────
 FROM node:20-alpine
 
-WORKDIR /app
+WORKDIR /workspace/services/formgen-service
 
-# Compiled output
-COPY --from=builder /workspace/services/formgen-service/dist ./dist
+COPY --from=builder /workspace/packages/formgen-shared /workspace/packages/formgen-shared
 
-# Production dependencies only
 COPY services/formgen-service/package*.json ./
 RUN npm install --omit=dev
+
+COPY --from=builder /workspace/services/formgen-service/dist ./dist
 
 EXPOSE 3014
 

--- a/formsync/services/formgen-service/Dockerfile
+++ b/formsync/services/formgen-service/Dockerfile
@@ -6,6 +6,11 @@ WORKDIR /workspace
 # Shared tsconfig — services extend ../../config/tsconfig.base.json
 COPY config/ config/
 
+COPY packages/form-types ./packages/form-types
+WORKDIR /workspace/packages/form-types
+RUN npm install && npm run build
+
+WORKDIR /workspace
 COPY packages/formgen-shared ./packages/formgen-shared
 WORKDIR /workspace/packages/formgen-shared
 RUN npm install && npm run build
@@ -23,6 +28,7 @@ FROM node:20-alpine
 WORKDIR /workspace/services/formgen-service
 
 COPY --from=builder /workspace/packages/formgen-shared /workspace/packages/formgen-shared
+COPY --from=builder /workspace/packages/form-types /workspace/packages/form-types
 
 COPY services/formgen-service/package*.json ./
 RUN npm install --omit=dev

--- a/formsync/services/formgen-service/package.json
+++ b/formsync/services/formgen-service/package.json
@@ -1,7 +1,7 @@
 {
     "name": "formgen-service",
     "version": "1.0.0",
-    "description": "FormSync React Code Generator Microservice — generates a standalone React app from a FormModel",
+    "description": "FormSync frontend bundle orchestrator — React app generation and fullstack ZIP with optional static HTML/Bootstrap",
     "main": "dist/server.js",
     "scripts": {
         "dev": "ts-node src/server.ts",
@@ -11,6 +11,7 @@
         "format": "prettier --write \"src/**/*.ts\""
     },
     "dependencies": {
+        "@formsync/formgen-shared": "file:../../packages/formgen-shared",
         "dotenv": "^16.3.1",
         "archiver": "^7.0.1",
         "axios": "^1.13.2",

--- a/formsync/services/formgen-service/package.json
+++ b/formsync/services/formgen-service/package.json
@@ -11,6 +11,7 @@
         "format": "prettier --write \"src/**/*.ts\""
     },
     "dependencies": {
+        "@formsync/form-types": "file:../../packages/form-types",
         "@formsync/formgen-shared": "file:../../packages/formgen-shared",
         "dotenv": "^16.3.1",
         "archiver": "^7.0.1",

--- a/formsync/services/formgen-service/src/generators/react-generator.ts
+++ b/formsync/services/formgen-service/src/generators/react-generator.ts
@@ -1,24 +1,89 @@
 /**
- * React Component Generator
- *
- * Converts FormModel to a React component (App.tsx).
- * This mirrors the rendering logic from Canvas.tsx to ensure visual parity.
+ * React Component Generator — FormModel → App.tsx (palette parity for ZIP exports).
  */
 
-import { FormModel, FieldModel } from '../types';
+import type { FieldModel, FormModel } from "../types";
 
-/**
- * Generate the complete App.tsx file
- */
+const AUTO_COMPLETE_MAP: Record<string, string> = {
+  name: "name",
+  firstName: "given-name",
+  lastName: "family-name",
+  email: "email",
+  phone: "tel",
+  mobile: "tel",
+  password: "current-password",
+  newPassword: "new-password",
+  street: "street-address",
+  city: "address-level2",
+  state: "address-level1",
+  zip: "postal-code",
+  country: "country-name",
+  organisation: "organization",
+  company: "organization",
+};
+
+export interface RepeaterCodegenCtx {
+  repeaterRoot: string;
+}
+
+function escapeJsSingleQuotedString(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+function sanitizeIdent(s: string): string {
+  return s.replace(/[^a-zA-Z0-9]/g, "_");
+}
+
+function relativeUnderRepeater(repeaterRoot: string, fieldKey: string): string {
+  if (fieldKey.startsWith(repeaterRoot + ".")) return fieldKey.slice(repeaterRoot.length + 1);
+  return fieldKey;
+}
+
+function staticNameAttr(field: FieldModel): string {
+  return `name="${escapeHtml(field.key)}"`;
+}
+
+/** JSX: name={\`root.${rowIdx}.rel\`} */
+function jsxRepeaterNameAttr(repeaterRoot: string, field: FieldModel): string {
+  const rel = relativeUnderRepeater(repeaterRoot, field.key);
+  const rootLit = repeaterRoot.replace(/\\/g, "\\\\").replace(/`/g, "\\`");
+  const relLit = rel.replace(/\\/g, "\\\\").replace(/`/g, "\\`");
+  return `name={\\\`${rootLit}.\\\${rowIdx}.${relLit}\\\`}`;
+}
+
+function jsxIdAttr(domBase: string, ctx?: RepeaterCodegenCtx): string {
+  if (!ctx) return `id="${escapeHtml(domBase)}"`;
+  const base = domBase.replace(/\\/g, "\\\\").replace(/`/g, "\\`");
+  return `id={\\\`${base}_\\\${rowIdx}\\\`}`;
+}
+
+function jsxHtmlForAttr(domBase: string, ctx?: RepeaterCodegenCtx): string {
+  if (!ctx) return `htmlFor="${escapeHtml(domBase)}"`;
+  const base = domBase.replace(/\\/g, "\\\\").replace(/`/g, "\\`");
+  return `htmlFor={\\\`${base}_\\\${rowIdx}\\\`}`;
+}
+
+function jsxErrorsLookup(repeaterRoot: string | undefined, field: FieldModel): string {
+  if (!repeaterRoot) return `errors['${escapeJsSingleQuotedString(field.key)}']`;
+  const rel = relativeUnderRepeater(repeaterRoot, field.key);
+  const rootLit = repeaterRoot.replace(/\\/g, "\\\\").replace(/`/g, "\\`");
+  const relLit = rel.replace(/\\/g, "\\\\").replace(/`/g, "\\`");
+  return `errors[\\\`${rootLit}.\\\${rowIdx}.${relLit}\\\`]`;
+}
+
+function jsxAriaDescribedBy(domBase: string, ctx?: RepeaterCodegenCtx): string {
+  if (!ctx) return `aria-describedby="${domBase}-help ${domBase}-error"`;
+  const b = domBase.replace(/\\/g, "\\\\").replace(/`/g, "\\`");
+  return `aria-describedby={\\\`${b}_\\\${rowIdx}-help ${b}_\\\${rowIdx}-error\\\`}`;
+}
+
 export function generateAppTsx(formModel: FormModel): string {
-  const { fields, layout, theme, meta, submit } = formModel;
+  const { fields, layout, meta, submit } = formModel;
 
-  // Get top-level fields in layout order
   const orderedFields = layout.order
-    .map(id => fields.find(f => f.id === id))
+    .map((id) => fields.find((f) => f.id === id))
     .filter((f): f is FieldModel => !!f);
 
-  // Stable DOM ids from semantic field keys (field_1, field_2, …) — not internal uuid ids
   const domIdByKey = new Map<string, string>();
   collectAllFields(orderedFields).forEach((f, i) => {
     domIdByKey.set(f.key, `field_${i + 1}`);
@@ -27,22 +92,32 @@ export function generateAppTsx(formModel: FormModel): string {
   const hasFields = orderedFields.length > 0;
   const title = meta?.title || formModel.name;
   const description = meta?.description;
-  const submitText = submit?.text || 'Submit';
+  const submitText = submit?.text || "Submit";
   const submitColor = submit?.color;
 
-  // Build the form body — grouped into step sections when wizard mode is on
+  const repeaterStates = orderedFields.filter((f) => f.type === "repeater").map((f) => ({
+    field: f,
+    stateVar: `repRowIds_${sanitizeIdent(f.key)}_${sanitizeIdent(f.id)}`,
+  }));
+
+  const repeaterStateDeclarations = repeaterStates
+    .map(
+      ({ stateVar }) =>
+        `  const [${stateVar}, set${stateVar.charAt(0).toUpperCase() + stateVar.slice(1)}] = useState<string[]>(() => ['0']);`,
+    )
+    .join("\n");
+
   let formBody: string;
   if (hasFields && layout.steps && layout.steps.length > 0) {
-    // Render each wizard step as a <section> with a heading
-    const sections = layout.steps.map((step, stepIdx) => {
-      // Fields for this step: either assigned to this step OR unassigned (stepIndex === undefined)
-      const stepFields = orderedFields.filter(
-        f => f.stepIndex === stepIdx || f.stepIndex === undefined
-      );
-      const fieldComponents = stepFields
-        .map(f => generateFieldComponent(f, theme, domIdByKey))
-        .join('\n\n');
-      return `<section className="form-section">
+    const sections = layout.steps
+      .map((step, stepIdx) => {
+        const stepFields = orderedFields.filter(
+          (f) => f.stepIndex === stepIdx || f.stepIndex === undefined,
+        );
+        const fieldComponents = stepFields
+          .map((f) => generateFieldComponent(f, domIdByKey, undefined, repeaterStates))
+          .join("\n\n");
+        return `<section className="form-section">
           <h2 className="section-title">
             <span className="section-number">${stepIdx + 1}</span>
             ${escapeHtml(step.title)}
@@ -51,84 +126,148 @@ export function generateAppTsx(formModel: FormModel): string {
             ${fieldComponents}
           </div>
         </section>`;
-    }).join('\n\n        ');
+      })
+      .join("\n\n        ");
 
-    formBody = `<form onSubmit={handleSubmit} noValidate>
+    formBody = `<form ref={formRef} onInput={() => setFormTick((v) => v + 1)} onSubmit={handleSubmit} noValidate>
         ${sections}
-
-        <button
-          type="submit"
-          className="submit-button"
-          ${submitColor ? `style={{ '--submit-bg-color': '${submitColor}' } as React.CSSProperties}` : ''}
-        >
-          ${escapeHtml(submitText)}
-        </button>
+        <button type="submit" className="submit-button" ${submitColor ? `style={{ '--submit-bg-color': '${submitColor}' } as React.CSSProperties}` : ""}>${escapeHtml(submitText)}</button>
       </form>`;
   } else if (hasFields) {
-    // Flat form — no wizard steps
     const fieldComponents = orderedFields
-      .map(f => generateFieldComponent(f, theme, domIdByKey))
-      .join('\n\n');
-    formBody = `<form onSubmit={handleSubmit} noValidate>
+      .map((f) => generateFieldComponent(f, domIdByKey, undefined, repeaterStates))
+      .join("\n\n");
+    formBody = `<form ref={formRef} onInput={() => setFormTick((v) => v + 1)} onSubmit={handleSubmit} noValidate>
         ${fieldComponents}
-
-        <button
-          type="submit"
-          className="submit-button"
-          ${submitColor ? `style={{ '--submit-bg-color': '${submitColor}' } as React.CSSProperties}` : ''}
-        >
-          ${escapeHtml(submitText)}
-        </button>
+        <button type="submit" className="submit-button" ${submitColor ? `style={{ '--submit-bg-color': '${submitColor}' } as React.CSSProperties}` : ""}>${escapeHtml(submitText)}</button>
       </form>`;
   } else {
     formBody = `<div className="empty-state">Form is empty.</div>`;
   }
 
-  // Build a static key → DOM-id map so the generated form can auto-focus
-  // the first invalid field without needing React refs.
   const allFields = collectAllFields(orderedFields);
   const fieldIdMapEntries = allFields
-    .map(
-      (f: FieldModel) =>
-        `  '${escapeJsSingleQuotedString(f.key)}': '${domIdByKey.get(f.key)}'`,
-    )
-    .join(',\n');
+    .map((f) => `  '${escapeJsSingleQuotedString(f.key)}': '${domIdByKey.get(f.key)}'`)
+    .join(",\n");
 
-  return `import React, { FormEvent, useState } from 'react';
+  const calcHelpers = `function evaluateCalcExpression(formula: string, values: Record<string, string>): string | number {
+  if (!formula) return '';
+  const interpolated = formula.replace(/\\{([^}]+)\\}/g, (_, key: string) => {
+    const k = key.trim();
+    const val = values[k];
+    return val !== undefined && val !== null ? String(val) : '0';
+  });
+  const isArithmetic = /^[\\d\\s+\\-*/().]+$/.test(interpolated);
+  if (isArithmetic) {
+    try {
+      const result = new Function('"use strict"; return (' + interpolated + ');')() as number;
+      return typeof result === 'number' && isFinite(result) ? result : interpolated;
+    } catch {
+      return interpolated;
+    }
+  }
+  return interpolated;
+}
 
-// Maps every field's form key to its DOM id.
-// Generated at build time — do not edit manually.
+function formValuesForCalc(form: HTMLFormElement | null): Record<string, string> {
+  if (!form) return {};
+  const fd = new FormData(form);
+  const out: Record<string, string> = {};
+  for (const [k, v] of fd.entries()) {
+    if (typeof v === 'string') out[k] = v;
+  }
+  return out;
+}
+
+function syncSignaturePads(form: HTMLFormElement | null) {
+  if (!form) return;
+  form.querySelectorAll<HTMLCanvasElement>('canvas[data-fs-sig-target]').forEach((canvas) => {
+    const hidId = canvas.getAttribute('data-fs-sig-target');
+    if (!hidId) return;
+    const hid = document.getElementById(hidId) as HTMLInputElement | null;
+    if (hid) hid.value = canvas.toDataURL('image/png');
+  });
+}
+`;
+
+  return `import React, { FormEvent, useState, useRef, useEffect } from 'react';
+
+${calcHelpers}
 const FIELD_ID_MAP: Record<string, string> = {
 ${fieldIdMapEntries}
 };
 
 function App() {
+  const formRef = useRef<HTMLFormElement>(null);
+  const [, setFormTick] = useState(0);
   const [errors, setErrors] = useState<Record<string, string>>({});
-  // Drives the aria-live announcement region — screen readers read this after submit.
   const [statusMessage, setStatusMessage] = useState<string>('');
+${repeaterStateDeclarations ? `\n${repeaterStateDeclarations}\n` : ""}
+
+  useEffect(() => {
+    const form = formRef.current;
+    if (!form) return;
+    const timers: Record<string, number> = {};
+    const cleanups: (() => void)[] = [];
+    form.querySelectorAll<HTMLInputElement>('input[data-typeahead-url]').forEach((input) => {
+      const urlTpl = input.dataset.typeaheadUrl || '';
+      const listId = input.getAttribute('list');
+      if (!listId || !urlTpl) return;
+      const dl = document.getElementById(listId);
+      if (!dl) return;
+      const onInput = () => {
+        const key = input.id || listId;
+        window.clearTimeout(timers[key]);
+        const q = input.value.trim();
+        timers[key] = window.setTimeout(() => {
+          const url = urlTpl.split('{query}').join(encodeURIComponent(q));
+          fetch(url)
+            .then((r) => r.json())
+            .then((data: unknown) => {
+              const arr = Array.isArray(data) ? data : [];
+              dl.innerHTML = '';
+              arr.slice(0, 50).forEach((item: unknown) => {
+                const opt = document.createElement('option');
+                const v =
+                  typeof item === 'string'
+                    ? item
+                    : String(
+                        (item as { label?: unknown }).label ??
+                          (item as { value?: unknown }).value ??
+                          item,
+                      );
+                opt.value = v;
+                dl.appendChild(opt);
+              });
+            })
+            .catch(() => {});
+        }, 300);
+      };
+      input.addEventListener('input', onInput);
+      cleanups.push(() => input.removeEventListener('input', onInput));
+    });
+    return () => cleanups.forEach((c) => c());
+  }, []);
 
   const validate = (data: Record<string, FormDataEntryValue>): Record<string, string> => {
     const errs: Record<string, string> = {};
-    // Add field-level validation here — key matches the field 'name' attribute.
-    // Example: if (!data['email']) errs['email'] = 'Email is required.';
     return errs;
   };
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    syncSignaturePads(e.currentTarget);
     const formData = new FormData(e.currentTarget);
     const data = Object.fromEntries(formData.entries());
     const errs = validate(data);
     setErrors(errs);
     const errorCount = Object.keys(errs).length;
     if (errorCount > 0) {
-      // Announce a summary to screen readers via the polite live region.
       setStatusMessage(
         errorCount === 1
           ? '1 error found. Please review the highlighted field.'
           : errorCount + ' errors found. Please review the highlighted fields.'
       );
-      // Move focus AND scroll to the first invalid field.
       const firstErrorKey = Object.keys(errs)[0];
       const firstErrorId = FIELD_ID_MAP[firstErrorKey];
       if (firstErrorId) {
@@ -139,7 +278,6 @@ function App() {
       return;
     }
     /* FORMSYNC_API_SUBMIT_START */
-    // Clear any prior status message on a clean submission.
     setStatusMessage('');
     console.log('Form submitted:', data);
     /* FORMSYNC_API_SUBMIT_END */
@@ -147,19 +285,11 @@ function App() {
 
   return (
     <div className="form-container">
-      {/* Visually hidden — screen readers announce statusMessage when it changes. */}
-      <div
-        role="status"
-        aria-live="polite"
-        aria-atomic="true"
-        className="sr-only"
-      >
+      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
         {statusMessage}
       </div>
-
       <h1 className="form-title">${escapeHtml(title)}</h1>
-      ${description ? `<p className="form-description">${escapeHtml(description)}</p>` : ''}
-
+      ${description ? `<p className="form-description">${escapeHtml(description)}</p>` : ""}
       ${formBody}
     </div>
   );
@@ -169,78 +299,87 @@ export default App;
 `;
 }
 
-
-/**
- * Generate JSX for a single field.
- * Handles different field types and applies style overrides as CSS custom properties.
- *
- * Design:
- *  - Style overrides become CSS vars scoped to the field wrapper (--field-label-color etc.)
- *  - A buildStyle() helper merges layout props + override vars into ONE style={} attribute
- *    to avoid the invalid-JSX duplicate-style-attribute pitfall.
- *  - Only non-empty override values emit a CSS var entry (no empty strings polluting styles).
- */
-/** WCAG 1.3.5 — maps field keys to HTML autocomplete tokens so password
- *  managers and assistive technology can identify the purpose of each input. */
-const AUTO_COMPLETE_MAP: Record<string, string> = {
-  name: 'name', firstName: 'given-name', lastName: 'family-name',
-  email: 'email', phone: 'tel', mobile: 'tel',
-  password: 'current-password', newPassword: 'new-password',
-  street: 'street-address', city: 'address-level2', state: 'address-level1',
-  zip: 'postal-code', country: 'country-name',
-  organisation: 'organization', company: 'organization',
-};
-
-function escapeJsSingleQuotedString(s: string): string {
-  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+interface RepeaterStateSpec {
+  field: FieldModel;
+  stateVar: string;
 }
 
 function generateFieldComponent(
   field: FieldModel,
-  theme: any,
   domIdByKey: Map<string, string>,
+  ctx: RepeaterCodegenCtx | undefined,
+  repeaterStates: RepeaterStateSpec[],
 ): string {
-  const { id, key, type, label, required, ui } = field;
-  const domId = domIdByKey.get(key) ?? id;
-  // date/number inputs don't benefit from placeholder — omit it to keep markup clean.
+  const { type, label, required, ui } = field;
+  const domBase = domIdByKey.get(field.key) ?? field.id;
+  const nameAttr = ctx ? jsxRepeaterNameAttr(ctx.repeaterRoot, field) : staticNameAttr(field);
+  const idAttr = jsxIdAttr(domBase, ctx);
+  const htmlForAttr = jsxHtmlForAttr(domBase, ctx);
+  const errExpr = jsxErrorsLookup(ctx?.repeaterRoot, field);
+  const ariaDescribedBy = jsxAriaDescribedBy(domBase, ctx);
+  const ariaInvalid = `aria-invalid={${errExpr} ? 'true' : 'false'}`;
+  const ariaErrMsg = ctx
+    ? `aria-errormessage={\\\`${domBase.replace(/`/g, "\\`")}_\\\${rowIdx}-error\\\`}`
+    : `aria-errormessage="${domBase}-error"`;
+
+  if (type === "repeater") {
+    const spec = repeaterStates.find((s) => s.field.id === field.id);
+    if (!spec) {
+      return `<div className="field-item"><p className="field-help-text">Repeater configuration error.</p></div>`;
+    }
+    const children = field.children || [];
+    if (children.some((c) => c.type === "repeater")) {
+      return `<div className="field-item border rounded p-3 mb-3">
+          <div className="field-label fw-semibold mb-2">${escapeHtml(label)}</div>
+          <p className="text-muted small">Nested repeaters are not supported in this export.</p>
+        </div>`;
+    }
+    const setterName = `set${spec.stateVar.charAt(0).toUpperCase()}${spec.stateVar.slice(1)}`;
+    const innerRows = children
+      .map((child) =>
+        generateFieldComponent(child, domIdByKey, { repeaterRoot: field.key }, repeaterStates),
+      )
+      .join("\n\n");
+
+    return `<fieldset className="field-group repeater-field mb-4" style={{ border: '1px solid #e5e7eb', borderRadius: '4px', padding: '1rem' }}>
+        <legend className="field-legend" style={{ padding: '0 0.5rem', fontWeight: 600 }}>${escapeHtml(label)}${required ? ' <span className="required" aria-hidden="true">*</span>' : ""}</legend>
+        {${spec.stateVar}.map((rowId, rowIdx) => (
+        <div key={rowId} className="repeater-row border rounded p-3 mb-3 bg-light">
+          ${innerRows}
+          <button type="button" className="btn btn-sm btn-outline-danger mt-2" onClick={() => ${setterName}((rows) => rows.length <= 1 ? rows : rows.filter((_, i) => i !== rowIdx))}>Remove row</button>
+        </div>
+        ))}
+        <button type="button" className="btn btn-sm btn-outline-primary" onClick={() => ${setterName}((rows) => [...rows, String(Date.now())])}>Add row</button>
+      </fieldset>`;
+  }
+
   const explicitPlaceholder = ui?.placeholder;
   const computedPlaceholder = explicitPlaceholder ?? `Enter ${label.toLowerCase()}...`;
-  const placeholder = type === 'date' ? '' : computedPlaceholder;
+  const placeholder = type === "date" ? "" : computedPlaceholder;
   const helpText = ui?.helpText;
   const overrides = ui?.styleOverrides as Record<string, string> | undefined;
-  // Look up autoComplete token for this field key (WCAG 1.3.5).
-  const autoComplete = AUTO_COMPLETE_MAP[key] ?? '';
+  const autoComplete = AUTO_COMPLETE_MAP[field.key] ?? "";
 
-  // Collect per-field CSS custom property entries (only truthy values)
   const overrideVars: string[] = overrides
-    ? [
-      overrides.labelColor && `'--field-label-color': '${overrides.labelColor}'`,
-      overrides.inputTextColor && `'--field-input-text-color': '${overrides.inputTextColor}'`,
-      overrides.backgroundColor && `'--field-bg-color': '${overrides.backgroundColor}'`,
-      overrides.borderColor && `'--field-border-color': '${overrides.borderColor}'`,
-      overrides.focusColor && `'--color-primary': '${overrides.focusColor}'`,
-    ].filter(Boolean) as string[]
+    ? ([
+        overrides.labelColor && `'--field-label-color': '${overrides.labelColor}'`,
+        overrides.inputTextColor && `'--field-input-text-color': '${overrides.inputTextColor}'`,
+        overrides.backgroundColor && `'--field-bg-color': '${overrides.backgroundColor}'`,
+        overrides.borderColor && `'--field-border-color': '${overrides.borderColor}'`,
+        overrides.focusColor && `'--color-primary': '${overrides.focusColor}'`,
+      ].filter(Boolean) as string[])
     : [];
 
-  /**
-   * Build a single style={{...}} attribute string that merges:
-   *  - Any extra layout properties (border, padding, display, …)
-   *  - The per-field CSS custom property overrides
-   * Returns an empty string when there is nothing to emit.
-   */
   const buildStyle = (extra: string[] = []): string => {
     const all = [...extra, ...overrideVars];
-    return all.length > 0
-      ? `style={{ ${all.join(', ')} } as React.CSSProperties}`
-      : '';
+    return all.length > 0 ? `style={{ ${all.join(", ")} } as React.CSSProperties}` : "";
   };
 
-  // ── group ──────────────────────────────────────────────────────────────────
-  if (type === 'group') {
+  if (type === "group") {
     const children = field.children || [];
     const childComponents = children
-      .map(child => generateFieldComponent(child, theme, domIdByKey))
-      .join('\n');
+      .map((child) => generateFieldComponent(child, domIdByKey, ctx, repeaterStates))
+      .join("\n");
     const groupExtra = [
       `border: '1px solid #e5e7eb'`,
       `borderRadius: '4px'`,
@@ -253,135 +392,247 @@ function generateFieldComponent(
         </fieldset>`;
   }
 
-  // ── input element ──────────────────────────────────────────────────────────
-  let inputElement: string;
-  // Build aria attributes shared across input types
-  // - aria-required: explicitly declares the field as required for AT
-  // - aria-describedby: links to help text and/or error message spans
-  // - aria-invalid: evaluated at runtime via {errors['key'] ? 'true' : 'false'}
-  // - aria-errormessage: points to the error span when invalid
-  const describedByParts: string[] = [];
-  if (helpText) describedByParts.push(`${domId}-help`);
-  describedByParts.push(`${domId}-error`);
-  const ariaDescribedBy = `aria-describedby="${describedByParts.join(' ')}"`;
-  const ariaRequired = required ? `aria-required="true"` : '';
-  const ariaInvalid = `aria-invalid={errors['${key}'] ? 'true' : 'false'}`;
-  const ariaErrMsg = `aria-errormessage="${domId}-error"`;
+  const ariaRequired = required ? `aria-required="true"` : "";
+  const autoCompleteAttr = autoComplete ? `autoComplete="${autoComplete}"` : "";
 
-  const autoCompleteAttr = autoComplete ? `autoComplete="${autoComplete}"` : '';
+  const helpSpan = helpText
+    ? ctx
+      ? `<small id={\\\`${domBase.replace(/`/g, "\\`")}_\\\${rowIdx}-help\\\`} className="field-help-text">${escapeHtml(helpText)}</small>`
+      : `<small id="${domBase}-help" className="field-help-text">${escapeHtml(helpText)}</small>`
+    : "";
+
+  const errSpan = ctx
+    ? `<span id={\\\`${domBase.replace(/`/g, "\\`")}_\\\${rowIdx}-error\\\`} className="field-error" role="alert" aria-live="polite">{${errExpr}}</span>`
+    : `<span id="${domBase}-error" className="field-error" role="alert" aria-live="polite">{${errExpr}}</span>`;
 
   switch (type) {
-    case 'textarea':
-      inputElement = `<textarea
-            name="${key}"
-            id="${domId}"
+    case "textarea":
+    case "richtext": {
+      const input = `<textarea
+            ${nameAttr}
+            ${idAttr}
             className="field-input"
-            ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ''}
-            ${required ? 'required' : ''}
+            ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ""}
+            ${required ? "required" : ""}
             ${ariaRequired}
             ${ariaInvalid}
             ${ariaErrMsg}
             ${ariaDescribedBy}
             ${autoCompleteAttr}
           ></textarea>`;
-      break;
-    case 'select': {
-      const options = field.constraints?.enum || [];
-      inputElement = `<select
-            name="${key}"
-            id="${domId}"
-            className="field-input"
-            ${required ? 'required' : ''}
-            ${ariaRequired}
-            ${ariaInvalid}
-            ${ariaErrMsg}
-            ${ariaDescribedBy}
-            ${autoCompleteAttr}
-          >
-            <option value="">${escapeHtml(placeholder) || 'Select...'}</option>
-            ${options.map(o => `<option value="${escapeHtml(o)}">${escapeHtml(o)}</option>`).join('\n            ')}
-          </select>`;
-      break;
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
     }
-    case 'checkbox':
-      // Checkboxes use aria-checked semantics; aria-required still applies.
-      // autoComplete is not applicable to checkboxes — omitted intentionally.
-      inputElement = `<input
+    case "select": {
+      const options = field.constraints?.enum || [];
+      const input = `<select
+            ${nameAttr}
+            ${idAttr}
+            className="field-input"
+            ${required ? "required" : ""}
+            ${ariaRequired}
+            ${ariaInvalid}
+            ${ariaErrMsg}
+            ${ariaDescribedBy}
+            ${autoCompleteAttr}
+          >
+            <option value="">${escapeHtml(placeholder) || "Select..."}</option>
+            ${options.map((o) => `<option value="${escapeHtml(o)}">${escapeHtml(o)}</option>`).join("\n            ")}
+          </select>`;
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
+    }
+    case "checkbox": {
+      const input = `<input
             type="checkbox"
-            name="${key}"
-            id="${domId}"
+            ${nameAttr}
+            ${idAttr}
             className="field-input"
             ${ariaRequired}
             ${ariaInvalid}
             ${ariaErrMsg}
             ${ariaDescribedBy}
           />`;
-      break;
-    default:
-      // text, email, password, number, date
-      inputElement = `<input
-            type="${type}"
-            name="${key}"
-            id="${domId}"
+      const rowStyle = [`display: 'flex'`, `alignItems: 'center'`, `flexWrap: 'wrap'`];
+      const cbHelpId =
+        ctx ?
+          `id={\\\`${domBase.replace(/`/g, "\\`")}_\\\${rowIdx}-help\\\`}`
+        : `id="${domBase}-help"`;
+      const cbHelp = helpText
+        ? `<small ${cbHelpId} className="field-help-text" style={{ marginLeft: 'auto' }}>${escapeHtml(helpText)}</small>`
+        : "";
+      return `<div className="field-item checkbox-item" ${buildStyle(rowStyle)}>
+          ${input}
+          <label ${htmlForAttr} className="field-label" style={{ marginBottom: 0 }}>
+            ${escapeHtml(label)}${required ? '<span className="required" aria-hidden="true">*</span>' : ""}
+          </label>
+          ${cbHelp}
+          ${errSpan}
+        </div>`;
+    }
+    case "file": {
+      const xui = ui?.["x-ui"];
+      const accept = xui?.accept ? `accept="${escapeHtml(String(xui.accept))}"` : "";
+      const multiple = xui?.multiple ? "multiple" : "";
+      const input = `<input
+            type="file"
+            ${nameAttr}
+            ${idAttr}
             className="field-input"
-            ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ''}
-            ${required ? 'required' : ''}
+            ${accept}
+            ${multiple}
+            ${required ? "required" : ""}
+            ${ariaRequired}
+            ${ariaInvalid}
+            ${ariaErrMsg}
+            ${ariaDescribedBy}
+          />`;
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
+    }
+    case "signature": {
+      const hidId = `${domBase}_sig`;
+      const hidIdExpr = ctx
+        ? `{\\\`${domBase.replace(/`/g, "\\`")}_\\\${rowIdx}_sig\\\`}`
+        : `"${escapeHtml(hidId)}"`;
+      const canvasIdExpr = ctx
+        ? `{\\\`${domBase.replace(/`/g, "\\`")}_\\\${rowIdx}_canvas\\\`}`
+        : `"${escapeHtml(domBase)}_canvas"`;
+      const sigTargetAttr = ctx
+        ? `data-fs-sig-target={\\\`${domBase.replace(/`/g, "\\`")}_\\\${rowIdx}_sig\\\`}`
+        : `data-fs-sig-target="${escapeHtml(hidId)}"`;
+      const input = `<canvas
+            id=${canvasIdExpr}
+            width={400}
+            height={160}
+            className="border rounded bg-white"
+            ${sigTargetAttr}
+            style={{ maxWidth: '100%', touchAction: 'none' }}
+            onPointerDown={(e) => {
+              const c = e.currentTarget;
+              const g = c.getContext('2d');
+              if (!g) return;
+              const rect = c.getBoundingClientRect();
+              let drawing = true;
+              g.beginPath();
+              g.strokeStyle = '#111';
+              g.lineWidth = 2;
+              g.moveTo(e.clientX - rect.left, e.clientY - rect.top);
+              const move = (ev: PointerEvent) => {
+                if (!drawing) return;
+                g.lineTo(ev.clientX - rect.left, ev.clientY - rect.top);
+                g.stroke();
+              };
+              const up = () => {
+                drawing = false;
+                c.removeEventListener('pointermove', move);
+              };
+              c.setPointerCapture(e.pointerId);
+              c.addEventListener('pointermove', move);
+              c.addEventListener('pointerup', up, { once: true });
+            }}
+          />
+          <input type="hidden" ${nameAttr} id=${hidIdExpr} />`;
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
+    }
+    case "typeahead": {
+      const url = ui?.["x-ui"]?.asyncSource?.url ?? "";
+      const dlId = `${domBase}_dl`;
+      const dlIdExpr = ctx
+        ? `{\\\`${domBase.replace(/`/g, "\\`")}_\\\${rowIdx}_dl\\\`}`
+        : `"${escapeHtml(dlId)}"`;
+      const input = `<input
+            type="text"
+            ${nameAttr}
+            ${idAttr}
+            className="field-input"
+            list=${dlIdExpr}
+            data-typeahead-url="${escapeHtml(url)}"
+            ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ""}
+            ${required ? "required" : ""}
+            ${ariaRequired}
+            ${ariaInvalid}
+            ${ariaErrMsg}
+            ${ariaDescribedBy}
+          />
+          <datalist id=${dlIdExpr}></datalist>`;
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
+    }
+    case "calculated": {
+      const formula = field["x-calc"] ?? "";
+      const input = `<input
+            readOnly
+            ${nameAttr}
+            ${idAttr}
+            className="field-input"
+            value={String(evaluateCalcExpression(${JSON.stringify(formula)}, formValuesForCalc(formRef.current)))}
+            ${ariaRequired}
+            ${ariaInvalid}
+            ${ariaErrMsg}
+            ${ariaDescribedBy}
+          />`;
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
+    }
+    case "text":
+    case "email":
+    case "password":
+    case "number":
+    case "date": {
+      const input = `<input
+            type="${type}"
+            ${nameAttr}
+            ${idAttr}
+            className="field-input"
+            ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ""}
+            ${required ? "required" : ""}
             ${ariaRequired}
             ${ariaInvalid}
             ${ariaErrMsg}
             ${ariaDescribedBy}
             ${autoCompleteAttr}
           />`;
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
+    }
+    case "unknown":
+    default: {
+      const input = `<input
+            type="text"
+            ${nameAttr}
+            ${idAttr}
+            className="field-input"
+            ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ""}
+            ${required ? "required" : ""}
+            ${ariaRequired}
+            ${ariaInvalid}
+            ${ariaErrMsg}
+            ${ariaDescribedBy}
+          />`;
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
+    }
   }
+}
 
-  // ── checkbox wrapper ─────────────────────────────────────────────────────
-  // Checkboxes render the label after the input; error lives below the group
-  if (type === 'checkbox') {
-    const checkboxExtra = [`display: 'flex'`, `alignItems: 'center'`, `flexWrap: 'wrap'`];
-    return `<div className="field-item checkbox-item" ${buildStyle(checkboxExtra)}>
-          ${inputElement}
-          <label htmlFor="${domId}" className="field-label" style={{ marginBottom: 0 }}>
-            ${escapeHtml(label)}${required ? '<span className="required" aria-hidden="true">*</span>' : ''}
-          </label>
-          ${helpText ? `<small id="${domId}-help" className="field-help-text" style={{ marginLeft: 'auto' }}>${escapeHtml(helpText)}</small>` : ''}
-          <span
-            id="${domId}-error"
-            className="field-error"
-            role="alert"
-            aria-live="polite"
-          >
-            {errors['${key}']}
-          </span>
-        </div>`;
-  }
-
-  // ── standard field wrapper ───────────────────────────────────────────────
+function wrapField(
+  label: string,
+  required: boolean,
+  htmlForAttr: string,
+  input: string,
+  buildStyle: (e?: string[]) => string,
+  helpSpan: string,
+  errSpan: string,
+): string {
   return `<div className="field-item" ${buildStyle()}>
-          <label htmlFor="${domId}" className="field-label">
-            ${escapeHtml(label)}${required ? '<span className="required" aria-hidden="true">*</span>' : ''}
+          <label ${htmlForAttr} className="field-label">
+            ${escapeHtml(label)}${required ? '<span className="required" aria-hidden="true">*</span>' : ""}
           </label>
-          ${inputElement}
-          ${helpText ? `<small id="${domId}-help" className="field-help-text">${escapeHtml(helpText)}</small>` : ''}
-          <span
-            id="${domId}-error"
-            className="field-error"
-            role="alert"
-            aria-live="polite"
-          >
-            {errors['${key}']}
-          </span>
+          ${input}
+          ${helpSpan}
+          ${errSpan}
         </div>`;
 }
 
-/**
- * Recursively collect every leaf field (including group children) so we can
- * build a complete key → id mapping used by FIELD_ID_MAP in the App component.
- */
 function collectAllFields(fields: FieldModel[]): FieldModel[] {
   const result: FieldModel[] = [];
   for (const f of fields) {
-    if (f.type === 'group' && f.children && f.children.length > 0) {
-      result.push(...collectAllFields(f.children));
+    if (f.type === "group" || f.type === "repeater") {
+      if (f.children?.length) result.push(...collectAllFields(f.children));
     } else {
       result.push(f);
     }
@@ -389,16 +640,13 @@ function collectAllFields(fields: FieldModel[]): FieldModel[] {
   return result;
 }
 
-/**
- * Escape HTML special characters to prevent XSS
- */
 function escapeHtml(text: string): string {
   const map: Record<string, string> = {
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#039;'
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#039;",
   };
-  return text.replace(/[&<>"']/g, m => map[m]);
+  return text.replace(/[&<>"']/g, (m) => map[m]);
 }

--- a/formsync/services/formgen-service/src/generators/react-generator.ts
+++ b/formsync/services/formgen-service/src/generators/react-generator.ts
@@ -2,7 +2,7 @@
  * React Component Generator — FormModel → App.tsx (palette parity for ZIP exports).
  */
 
-import type { FieldModel, FormModel } from "../types";
+import type { FieldModel, FormModel, FormStep } from "../types";
 
 const AUTO_COMPLETE_MAP: Record<string, string> = {
   name: "name",
@@ -81,11 +81,11 @@ export function generateAppTsx(formModel: FormModel): string {
   const { fields, layout, meta, submit } = formModel;
 
   const orderedFields = layout.order
-    .map((id) => fields.find((f) => f.id === id))
+    .map((id: string) => fields.find((f: FieldModel) => f.id === id))
     .filter((f): f is FieldModel => !!f);
 
   const domIdByKey = new Map<string, string>();
-  collectAllFields(orderedFields).forEach((f, i) => {
+  collectAllFields(orderedFields).forEach((f: FieldModel, i: number) => {
     domIdByKey.set(f.key, `field_${i + 1}`);
   });
 
@@ -95,14 +95,14 @@ export function generateAppTsx(formModel: FormModel): string {
   const submitText = submit?.text || "Submit";
   const submitColor = submit?.color;
 
-  const repeaterStates = orderedFields.filter((f) => f.type === "repeater").map((f) => ({
+  const repeaterStates = orderedFields.filter((f: FieldModel) => f.type === "repeater").map((f: FieldModel) => ({
     field: f,
     stateVar: `repRowIds_${sanitizeIdent(f.key)}_${sanitizeIdent(f.id)}`,
   }));
 
   const repeaterStateDeclarations = repeaterStates
     .map(
-      ({ stateVar }) =>
+      ({ stateVar }: { stateVar: string }) =>
         `  const [${stateVar}, set${stateVar.charAt(0).toUpperCase() + stateVar.slice(1)}] = useState<string[]>(() => ['0']);`,
     )
     .join("\n");
@@ -110,12 +110,12 @@ export function generateAppTsx(formModel: FormModel): string {
   let formBody: string;
   if (hasFields && layout.steps && layout.steps.length > 0) {
     const sections = layout.steps
-      .map((step, stepIdx) => {
+      .map((step: FormStep, stepIdx: number) => {
         const stepFields = orderedFields.filter(
-          (f) => f.stepIndex === stepIdx || f.stepIndex === undefined,
+          (f: FieldModel) => f.stepIndex === stepIdx || f.stepIndex === undefined,
         );
         const fieldComponents = stepFields
-          .map((f) => generateFieldComponent(f, domIdByKey, undefined, repeaterStates))
+          .map((f: FieldModel) => generateFieldComponent(f, domIdByKey, undefined, repeaterStates))
           .join("\n\n");
         return `<section className="form-section">
           <h2 className="section-title">
@@ -135,7 +135,7 @@ export function generateAppTsx(formModel: FormModel): string {
       </form>`;
   } else if (hasFields) {
     const fieldComponents = orderedFields
-      .map((f) => generateFieldComponent(f, domIdByKey, undefined, repeaterStates))
+      .map((f: FieldModel) => generateFieldComponent(f, domIdByKey, undefined, repeaterStates))
       .join("\n\n");
     formBody = `<form ref={formRef} onInput={() => setFormTick((v) => v + 1)} onSubmit={handleSubmit} noValidate>
         ${fieldComponents}
@@ -147,7 +147,7 @@ export function generateAppTsx(formModel: FormModel): string {
 
   const allFields = collectAllFields(orderedFields);
   const fieldIdMapEntries = allFields
-    .map((f) => `  '${escapeJsSingleQuotedString(f.key)}': '${domIdByKey.get(f.key)}'`)
+    .map((f: FieldModel) => `  '${escapeJsSingleQuotedString(f.key)}': '${domIdByKey.get(f.key)}'`)
     .join(",\n");
 
   const calcHelpers = `function evaluateCalcExpression(formula: string, values: Record<string, string>): string | number {
@@ -328,7 +328,7 @@ function generateFieldComponent(
       return `<div className="field-item"><p className="field-help-text">Repeater configuration error.</p></div>`;
     }
     const children = field.children || [];
-    if (children.some((c) => c.type === "repeater")) {
+    if (children.some((c: FieldModel) => c.type === "repeater")) {
       return `<div className="field-item border rounded p-3 mb-3">
           <div className="field-label fw-semibold mb-2">${escapeHtml(label)}</div>
           <p className="text-muted small">Nested repeaters are not supported in this export.</p>
@@ -336,7 +336,7 @@ function generateFieldComponent(
     }
     const setterName = `set${spec.stateVar.charAt(0).toUpperCase()}${spec.stateVar.slice(1)}`;
     const innerRows = children
-      .map((child) =>
+      .map((child: FieldModel) =>
         generateFieldComponent(child, domIdByKey, { repeaterRoot: field.key }, repeaterStates),
       )
       .join("\n\n");
@@ -378,7 +378,7 @@ function generateFieldComponent(
   if (type === "group") {
     const children = field.children || [];
     const childComponents = children
-      .map((child) => generateFieldComponent(child, domIdByKey, ctx, repeaterStates))
+      .map((child: FieldModel) => generateFieldComponent(child, domIdByKey, ctx, repeaterStates))
       .join("\n");
     const groupExtra = [
       `border: '1px solid #e5e7eb'`,
@@ -436,7 +436,7 @@ function generateFieldComponent(
             ${autoCompleteAttr}
           >
             <option value="">${escapeHtml(placeholder) || "Select..."}</option>
-            ${options.map((o) => `<option value="${escapeHtml(o)}">${escapeHtml(o)}</option>`).join("\n            ")}
+            ${options.map((o: string) => `<option value="${escapeHtml(o)}">${escapeHtml(o)}</option>`).join("\n            ")}
           </select>`;
       return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
     }

--- a/formsync/services/formgen-service/src/generators/templates.ts
+++ b/formsync/services/formgen-service/src/generators/templates.ts
@@ -444,6 +444,21 @@ This form was generated from FormSync Form Builder.
 ${formModel.meta?.title ? `- **Title**: ${formModel.meta.title}` : ''}
 ${formModel.meta?.description ? `- **Description**: ${formModel.meta.description}` : ''}
 
+## ZIP export (builder palette parity)
+
+Exported React and wired POST payloads align with the builder **field types**: text through calculated/repeater/typeahead, plus **unknown** (fallback).
+
+- **Files**: uploaded files are sent as **Base64 / data URL strings inside JSON** (not multipart). Expect practical limits on payload size from browsers and servers.
+- **Rich text**: exported as a **textarea** (HTML string). Bundle a rich-text library if you need WYSIWYG.
+- **Repeater**: values serialize as **arrays of objects** (indexed names like \`items.0.field\` → JSON arrays after submit wiring).
+- **Typeahead**: optional async URL must allow **CORS** from your dev origin; placeholder is \`{query}\`.
+
+### Manual smoke checklist
+
+1. Export fullstack ZIP with **group + repeater + file + calculated** fields; run frontend and POST to generated API.
+2. Confirm repeater rows produce a JSON **array** at the expected path.
+3. Confirm a small image/PDF file round-trips as Base64 in the JSON body (size stays reasonable).
+
 ## Customization
 
 - Edit \`src/App.tsx\` to modify the form structure

--- a/formsync/services/formgen-service/src/server.ts
+++ b/formsync/services/formgen-service/src/server.ts
@@ -33,6 +33,7 @@ import {
   generateIndexCss,
   generateReadme,
 } from "./generators";
+import { buildReactWiredSubmitReplacement } from "@formsync/formgen-shared";
 
 function buildFormModelFromSchema(schema: any): FormModel {
   const raw = schema?.content || schema;
@@ -140,6 +141,7 @@ function buildFormModelFromSchema(schema: any): FormModel {
 const app = express();
 const port = process.env.FORMGEN_SERVICE_PORT || 3014;
 type BackendLanguage = "springBoot" | "nodeExpress" | "dotnetWebApi";
+type FrontendStack = "react" | "htmlBootstrap";
 
 app.use(cors());
 app.use(express.json({ limit: "5mb" }));
@@ -149,6 +151,8 @@ const NODE_BACKEND_GENERATOR_URL =
   process.env.NODE_BACKEND_GENERATOR_URL || "http://localhost:3015";
 const DOTNET_BACKEND_GENERATOR_URL =
   process.env.DOTNET_BACKEND_GENERATOR_URL || "http://localhost:3016";
+const STATIC_FRONTEND_GENERATOR_URL =
+  process.env.STATIC_FRONTEND_GENERATOR_URL || "http://localhost:3017";
 
 function toKebabCase(input: string): string {
   return input
@@ -225,110 +229,11 @@ function wireFrontendApp(
   backendPort: number,
 ): string {
   const serializedFieldTypes = JSON.stringify(collectFieldTypeMap(formModel), null, 2);
-  const replacement = `${FORMSYNC_SUBMIT_START}
-    setStatusMessage('');
-    try {
-      const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:${backendPort}";
-      const API_PATH = import.meta.env.VITE_API_PATH || "${apiPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}";
-      const FIELD_TYPES: Record<string, string> = ${serializedFieldTypes};
-
-      const setDeepValue = (target: Record<string, any>, path: string, value: any) => {
-        const parts = path.split(".");
-        let current: Record<string, any> = target;
-        for (let i = 0; i < parts.length - 1; i++) {
-          const segment = parts[i];
-          if (
-            typeof current[segment] !== "object" ||
-            current[segment] === null ||
-            Array.isArray(current[segment])
-          ) {
-            current[segment] = {};
-          }
-          current = current[segment];
-        }
-        current[parts[parts.length - 1]] = value;
-      };
-
-      const coerceValue = (fieldType: string | undefined, rawValue: FormDataEntryValue) => {
-        if (fieldType === "number") {
-          const value = typeof rawValue === "string" ? rawValue.trim() : String(rawValue);
-          if (!value) return null;
-          const numeric = Number(value);
-          return Number.isNaN(numeric) ? null : numeric;
-        }
-        if (fieldType === "checkbox") {
-          if (typeof rawValue !== "string") return false;
-          return rawValue === "on" || rawValue === "true" || rawValue === "1";
-        }
-        return rawValue;
-      };
-
-      /** Drop "", null, undefined so Jackson never sees empty strings for Java enums or optional dates. */
-      const stripEmptyJsonValues = (value: unknown): unknown => {
-        if (value === "" || value === null || value === undefined) return undefined;
-        if (typeof value !== "object") return value;
-        if (Array.isArray(value)) {
-          return value
-            .map(stripEmptyJsonValues)
-            .filter((v) => v !== undefined);
-        }
-        const obj = value as Record<string, unknown>;
-        const out: Record<string, unknown> = {};
-        for (const [k, v] of Object.entries(obj)) {
-          const s = stripEmptyJsonValues(v);
-          if (s === undefined) continue;
-          if (
-            typeof s === "object" &&
-            s !== null &&
-            !Array.isArray(s) &&
-            Object.keys(s as Record<string, unknown>).length === 0
-          ) {
-            continue;
-          }
-          out[k] = s;
-        }
-        return out;
-      };
-
-      const toPayload = (form: HTMLFormElement) => {
-        const payload: Record<string, any> = {};
-        const formData = new FormData(form);
-
-        for (const [key, value] of formData.entries()) {
-          setDeepValue(payload, key, coerceValue(FIELD_TYPES[key], value));
-        }
-
-        const checkboxes = Array.from(
-          form.querySelectorAll<HTMLInputElement>('input[type="checkbox"][name]'),
-        );
-        for (const checkbox of checkboxes) {
-          if (!checkbox.checked) {
-            setDeepValue(payload, checkbox.name, false);
-          }
-        }
-
-        return payload;
-      };
-
-      const payload = toPayload(e.currentTarget);
-      const jsonBody = stripEmptyJsonValues(payload);
-      const response = await fetch(\`\${API_BASE_URL}\${API_PATH}\`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(jsonBody !== undefined ? jsonBody : {}),
-      });
-
-      if (!response.ok) {
-        throw new Error(\`Submission failed (\${response.status})\`);
-      }
-
-      alert("Submitted successfully");
-      console.log("Form submitted:", jsonBody !== undefined ? jsonBody : {});
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : "Submission failed";
-      setStatusMessage(msg);
-    }
-    ${FORMSYNC_SUBMIT_END}`;
+  const replacement = buildReactWiredSubmitReplacement({
+    serializedFieldTypes,
+    apiPath,
+    backendPort,
+  });
 
   const withAsyncSubmit = appTsx.replace(
     "const handleSubmit = (e: FormEvent<HTMLFormElement>) => {",
@@ -351,7 +256,11 @@ function wireFrontendApp(
   );
 }
 
-function generateBundleReadme(backendLanguage: BackendLanguage, backendPort: number): string {
+function generateBundleReadme(
+  backendLanguage: BackendLanguage,
+  backendPort: number,
+  frontendStack: FrontendStack,
+): string {
   const backendLabel =
     backendLanguage === "springBoot" ? "Spring Boot (Java)" :
     backendLanguage === "dotnetWebApi" ? "ASP.NET Core Web API (.NET 8)" :
@@ -369,10 +278,39 @@ function generateBundleReadme(backendLanguage: BackendLanguage, backendPort: num
         ? "cd backend\ndotnet run"
         : "cd backend\nnpm install\nnpm run start";
 
+  const frontendBullets =
+    frontendStack === "htmlBootstrap"
+      ? "- `frontend/` (static HTML + Bootstrap + JavaScript — no build step)"
+      : "- `frontend/` (Vite + React)";
+
+  const frontendSection =
+    frontendStack === "htmlBootstrap"
+      ? `## Run Frontend (static)
+
+\`\`\`bash
+cd frontend
+npx serve .
+\`\`\`
+
+Open the URL shown in the terminal. API URL is embedded in \`frontend/js/app.js\` for fullstack bundles (adjust if needed). Ensure your backend allows **CORS** from the origin you use to open the static files.
+`
+      : `## Run Frontend (Vite + React)
+
+\`\`\`bash
+cd frontend
+npm install
+npm run dev
+\`\`\`
+
+Dev server defaults to \`http://localhost:5170\` (see \`vite.config.ts\`).
+
+Frontend reads backend URL from \`frontend/.env\`.
+`;
+
   return `# Fullstack Generated Project
 
 This package includes:
-- \`frontend/\` (Vite + React)
+${frontendBullets}
 - \`backend/\` (${backendLabel})
 
 ## Prerequisites
@@ -389,18 +327,7 @@ ${backendRun}
 
 Backend default URL: \`http://localhost:${backendPort}\`
 
-## Run Frontend
-
-\`\`\`bash
-cd frontend
-npm install
-npm run dev
-\`\`\`
-
-Dev server defaults to \`http://localhost:5170\` (see \`vite.config.ts\`).
-
-Frontend reads backend URL from \`frontend/.env\`.
-`;
+${frontendSection}`;
 }
 
 function hasPathPrefix(
@@ -520,7 +447,13 @@ app.post("/generate-fullstack", async (req, res) => {
     formModel,
     schema,
     backendLanguage = "springBoot",
-  }: { formModel?: FormModel; schema: any; backendLanguage?: BackendLanguage } = req.body;
+    frontendStack = "react",
+  }: {
+    formModel?: FormModel;
+    schema: any;
+    backendLanguage?: BackendLanguage;
+    frontendStack?: FrontendStack;
+  } = req.body;
 
   if (!schema) {
     return res
@@ -534,6 +467,12 @@ app.post("/generate-fullstack", async (req, res) => {
       .json({ error: "backendLanguage must be springBoot, nodeExpress, or dotnetWebApi" });
   }
 
+  if (!["react", "htmlBootstrap"].includes(frontendStack)) {
+    return res
+      .status(400)
+      .json({ error: "frontendStack must be react or htmlBootstrap" });
+  }
+
   const requestId = crypto.randomUUID();
   const tempDir = path.join(os.tmpdir(), `formgen-fullstack-${requestId}`);
   const frontendDir = path.join(tempDir, "frontend");
@@ -541,27 +480,54 @@ app.post("/generate-fullstack", async (req, res) => {
 
   try {
     await fs.ensureDir(frontendDir);
-    await fs.ensureDir(path.join(frontendDir, "src"));
     await fs.ensureDir(backendDir);
+    if (frontendStack === "react") {
+      await fs.ensureDir(path.join(frontendDir, "src"));
+    }
 
     const effectiveFormModel = formModel || buildFormModelFromSchema(schema);
-    const frontendFiles = generateFrontendFiles(effectiveFormModel);
     const apiPath = getPrimaryApiPath(effectiveFormModel, backendLanguage);
     const backendPort = backendLanguage === "springBoot" ? 8080 : backendLanguage === "dotnetWebApi" ? 5000 : 3600;
 
-    // Patch generated frontend to submit directly to generated backend.
-    frontendFiles["src/App.tsx"] = wireFrontendApp(
-      frontendFiles["src/App.tsx"],
-      apiPath,
-      effectiveFormModel,
-      backendPort,
-    );
-    frontendFiles[".env"] = `VITE_API_URL=http://localhost:${backendPort}\nVITE_API_PATH=${apiPath}\n`;
+    if (frontendStack === "react") {
+      const frontendFiles = generateFrontendFiles(effectiveFormModel);
+      frontendFiles["src/App.tsx"] = wireFrontendApp(
+        frontendFiles["src/App.tsx"],
+        apiPath,
+        effectiveFormModel,
+        backendPort,
+      );
+      frontendFiles[".env"] = `VITE_API_URL=http://localhost:${backendPort}\nVITE_API_PATH=${apiPath}\n`;
 
-    for (const [filePath, content] of Object.entries(frontendFiles)) {
-      const fullPath = path.join(frontendDir, filePath);
-      await fs.ensureDir(path.dirname(fullPath));
-      await fs.writeFile(fullPath, content, "utf8");
+      for (const [filePath, content] of Object.entries(frontendFiles)) {
+        const fullPath = path.join(frontendDir, filePath);
+        await fs.ensureDir(path.dirname(fullPath));
+        await fs.writeFile(fullPath, content, "utf8");
+      }
+    } else {
+      const staticResp = await axios.post(
+        `${STATIC_FRONTEND_GENERATOR_URL}/generate`,
+        {
+          formModel: effectiveFormModel,
+          preview: true,
+          wiring: {
+            apiBaseUrl: `http://localhost:${backendPort}`,
+            apiPath,
+          },
+        },
+        { timeout: 120000 },
+      );
+      const staticFiles = staticResp.data?.files as
+        | Array<{ path: string; content: string }>
+        | undefined;
+      if (!staticFiles || !Array.isArray(staticFiles) || staticFiles.length === 0) {
+        throw new Error("Static frontend generator returned no files");
+      }
+      for (const sf of staticFiles) {
+        const fullPath = path.join(frontendDir, sf.path);
+        await fs.ensureDir(path.dirname(fullPath));
+        await fs.writeFile(fullPath, sf.content, "utf8");
+      }
     }
 
     const targetUrl =
@@ -592,15 +558,15 @@ app.post("/generate-fullstack", async (req, res) => {
 
     await fs.writeFile(
       path.join(tempDir, "README.md"),
-      generateBundleReadme(backendLanguage, backendPort),
+      generateBundleReadme(backendLanguage, backendPort, frontendStack),
       "utf8",
     );
 
     const schemaSlug = effectiveFormModel.name
       .toLowerCase()
       .replace(/\s+/g, "-");
-    /** Fullstack bundle is React + selected backend; FE slug reserved for future stacks. */
-    const frontendSlug = "react";
+    const frontendSlug =
+      frontendStack === "htmlBootstrap" ? "html-bootstrap" : "react";
     res.attachment(
       `${schemaSlug}_fullstack-${frontendSlug}_${backendLanguage}.zip`,
     );
@@ -637,6 +603,8 @@ app.get('/health', (_req, res) => {
 app.listen(port, () => {
   console.log(`🚀 formgen-service listening at http://localhost:${port}`);
   console.log(`   POST /generate-react  — Generate a standalone React app ZIP`);
-  console.log(`   POST /generate-fullstack — Generate frontend + selected backend`);
+  console.log(
+    `   POST /generate-fullstack — Fullstack (frontendStack: react | htmlBootstrap)`,
+  );
   console.log(`   GET  /health          — Health check`);
 });

--- a/formsync/services/formgen-service/src/types/index.ts
+++ b/formsync/services/formgen-service/src/types/index.ts
@@ -1,111 +1,22 @@
 /**
- * Local type definitions for formgen-service.
- *
- * Inlined from packages/formgen-core so this service has zero shared-package coupling.
+ * Re-export canonical FormModel types from @formsync/form-types.
  */
 
-export type FieldType =
-  | 'text'
-  | 'email'
-  | 'password'
-  | 'number'
-  | 'select'
-  | 'checkbox'
-  | 'textarea'
-  | 'date'
-  | 'group'
-  | 'unknown';
-
-export interface FieldConstraints {
-  min?: number;
-  max?: number;
-  minLength?: number;
-  maxLength?: number;
-  pattern?: string;
-  enum?: string[];
-  [key: string]: string | number | boolean | string[] | undefined;
-}
-
-export interface FieldStyleOverrides {
-  labelColor?: string;
-  inputTextColor?: string;
-  borderColor?: string;
-  backgroundColor?: string;
-  focusColor?: string;
-}
-
-export interface FieldUIConfig {
-  placeholder?: string;
-  helpText?: string;
-  hidden?: boolean;
-  disabled?: boolean;
-  style?: Record<string, string | number>;
-  styleOverrides?: FieldStyleOverrides;
-  [key: string]: string | number | boolean | Record<string, unknown> | FieldStyleOverrides | undefined;
-}
-
-export interface FieldModel {
-  id: string;
-  key: string;
-  type: FieldType;
-  label: string;
-  required: boolean;
-  defaultValue?: string | number | boolean | null;
-  constraints?: FieldConstraints;
-  ui?: FieldUIConfig;
-  children?: FieldModel[];
-  /** Wizard step index this field belongs to (0-based). Undefined = all steps. */
-  stepIndex?: number;
-}
-
-export interface ThemeColors {
-  primary: string;
-  background: string;
-  surface: string;
-  text: string;
-  muted: string;
-  border: string;
-  error: string;
-  inputBackground: string;
-}
-
-export interface ThemeConfig {
-  mode: 'light' | 'dark';
-  density: 'compact' | 'normal' | 'comfortable';
-  colors: ThemeColors;
-  schemes?: {
-    light: ThemeColors;
-    dark: ThemeColors;
-  };
-  typography: {
-    fontFamily: string;
-    baseFontSize: number;
-  };
-  radius: number;
-  primaryColor?: string;
-}
-
-export interface LayoutConfig {
-  order: string[];
-  /** Wizard steps. When present, fields are grouped by their stepIndex. */
-  steps?: Array<{ id: string; title: string }>;
-}
-
-export interface SubmitConfig {
-  text: string;
-  color?: string;
-}
-
-export interface FormModel {
-  id: string;
-  name: string;
-  version: string;
-  meta?: {
-    title?: string;
-    description?: string;
-  };
-  theme: ThemeConfig;
-  layout: LayoutConfig;
-  fields: FieldModel[];
-  submit?: SubmitConfig;
-}
+export type {
+  FieldType,
+  FieldModel,
+  FieldConstraints,
+  FieldUIConfig,
+  FieldXUI,
+  AsyncSourceConfig,
+  FieldConditions,
+  ConditionRule,
+  ConditionOperator,
+  FieldStyleOverrides,
+  ThemeColors,
+  ThemeConfig,
+  LayoutConfig,
+  FormStep,
+  SubmitConfig,
+  FormModel,
+} from "@formsync/form-types";

--- a/formsync/services/static-frontend-generator/Dockerfile
+++ b/formsync/services/static-frontend-generator/Dockerfile
@@ -5,6 +5,11 @@ WORKDIR /workspace
 
 COPY config/ config/
 
+COPY packages/form-types ./packages/form-types
+WORKDIR /workspace/packages/form-types
+RUN npm install && npm run build
+
+WORKDIR /workspace
 COPY packages/formgen-shared ./packages/formgen-shared
 WORKDIR /workspace/packages/formgen-shared
 RUN npm install && npm run build
@@ -22,6 +27,7 @@ FROM node:20-alpine
 WORKDIR /workspace/services/static-frontend-generator
 
 COPY --from=builder /workspace/packages/formgen-shared /workspace/packages/formgen-shared
+COPY --from=builder /workspace/packages/form-types /workspace/packages/form-types
 
 COPY services/static-frontend-generator/package*.json ./
 RUN npm install --omit=dev

--- a/formsync/services/static-frontend-generator/Dockerfile
+++ b/formsync/services/static-frontend-generator/Dockerfile
@@ -1,0 +1,33 @@
+# ── Build stage ────────────────────────────────────────────────
+FROM node:20-alpine AS builder
+
+WORKDIR /workspace
+
+COPY config/ config/
+
+COPY packages/formgen-shared ./packages/formgen-shared
+WORKDIR /workspace/packages/formgen-shared
+RUN npm install && npm run build
+
+WORKDIR /workspace/services/static-frontend-generator
+COPY services/static-frontend-generator/package*.json ./
+RUN npm install
+
+COPY services/static-frontend-generator/ .
+RUN npm run build
+
+# ── Runtime stage ──────────────────────────────────────────────
+FROM node:20-alpine
+
+WORKDIR /workspace/services/static-frontend-generator
+
+COPY --from=builder /workspace/packages/formgen-shared /workspace/packages/formgen-shared
+
+COPY services/static-frontend-generator/package*.json ./
+RUN npm install --omit=dev
+
+COPY --from=builder /workspace/services/static-frontend-generator/dist ./dist
+
+EXPOSE 3017
+
+CMD ["node", "dist/server.js"]

--- a/formsync/services/static-frontend-generator/package.json
+++ b/formsync/services/static-frontend-generator/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write \"src/**/*.ts\""
   },
   "dependencies": {
+    "@formsync/form-types": "file:../../packages/form-types",
     "@formsync/formgen-shared": "file:../../packages/formgen-shared",
     "archiver": "^7.0.1",
     "cors": "^2.8.5",

--- a/formsync/services/static-frontend-generator/package.json
+++ b/formsync/services/static-frontend-generator/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "static-frontend-generator",
+  "version": "1.0.0",
+  "description": "Generates static HTML + Bootstrap + JS from FormModel",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "dev": "ts-node src/server.ts",
+    "lint": "eslint \"src/**/*.ts\" --fix",
+    "format": "prettier --write \"src/**/*.ts\""
+  },
+  "dependencies": {
+    "@formsync/formgen-shared": "file:../../packages/formgen-shared",
+    "archiver": "^7.0.1",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^5.2.1",
+    "fs-extra": "^11.3.3"
+  },
+  "devDependencies": {
+    "@types/archiver": "^7.0.0",
+    "@types/cors": "^2.8.19",
+    "@types/express": "^5.0.6",
+    "@types/fs-extra": "^11.0.4",
+    "@types/node": "^20.10.5",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.2.2"
+  }
+}

--- a/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
+++ b/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
@@ -1,6 +1,6 @@
 /**
  * Static HTML + Bootstrap 5 + vanilla JS from FormModel.
- * Field markup aligned with react-generator semantics.
+ * Field markup aligned with react-generator semantics (palette parity).
  */
 
 import { buildVanillaWiredSubmitReplacement } from "@formsync/formgen-shared";
@@ -29,6 +29,11 @@ export interface StaticGeneratorWiring {
   apiPath: string;
 }
 
+export interface RepeaterCtx {
+  repeaterRoot: string;
+  rowIdx: number;
+}
+
 function escapeHtml(text: string): string {
   const map: Record<string, string> = {
     "&": "&amp;",
@@ -40,10 +45,27 @@ function escapeHtml(text: string): string {
   return text.replace(/[&<>"']/g, (m) => map[m]);
 }
 
+function relativeUnderRepeater(repeaterRoot: string, fieldKey: string): string {
+  if (fieldKey.startsWith(repeaterRoot + ".")) return fieldKey.slice(repeaterRoot.length + 1);
+  return fieldKey;
+}
+
+/** Indexed name for repeater rows (matches React export). */
+function indexedName(repeaterRoot: string, field: FieldModel, rowIdx: number): string {
+  const rel = relativeUnderRepeater(repeaterRoot, field.key);
+  return `${repeaterRoot}.${rowIdx}.${rel}`;
+}
+
+function domIdFor(field: FieldModel, domIdByKey: Map<string, string>, ctx?: RepeaterCtx): string {
+  const base = domIdByKey.get(field.key) ?? field.id;
+  if (!ctx) return base;
+  return `${base}_r${ctx.rowIdx}`;
+}
+
 function collectAllFields(fields: FieldModel[]): FieldModel[] {
   const result: FieldModel[] = [];
   for (const f of fields) {
-    if (f.type === "group" && f.children && f.children.length > 0) {
+    if ((f.type === "group" || f.type === "repeater") && f.children?.length) {
       result.push(...collectAllFields(f.children));
     } else {
       result.push(f);
@@ -52,18 +74,40 @@ function collectAllFields(fields: FieldModel[]): FieldModel[] {
   return result;
 }
 
-function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, string>): string {
-  const { id, key, type, label, required, ui } = field;
-  const domId = domIdByKey.get(key) ?? id;
+function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, string>, ctx?: RepeaterCtx): string {
+  const { key, type, label, required, ui } = field;
+  const nameAttr = ctx ? escapeHtml(indexedName(ctx.repeaterRoot, field, ctx.rowIdx)) : escapeHtml(key);
+  const domId = domIdFor(field, domIdByKey, ctx);
   const explicitPlaceholder = ui?.placeholder;
   const computedPlaceholder = explicitPlaceholder ?? `Enter ${label.toLowerCase()}...`;
   const placeholder = type === "date" ? "" : computedPlaceholder;
   const helpText = ui?.helpText;
   const autoComplete = AUTO_COMPLETE_MAP[key] ?? "";
 
+  if (type === "repeater") {
+    const children = field.children || [];
+    if (children.some((c) => c.type === "repeater")) {
+      return `<div class="border rounded p-3 mb-4"><p class="text-muted small mb-0">Nested repeaters are not supported in this export.</p></div>`;
+    }
+    const inner = children
+      .map((c) => generateBootstrapField(c, domIdByKey, { repeaterRoot: field.key, rowIdx: 0 }))
+      .join("\n");
+    const rootEsc = escapeHtml(field.key);
+    return `<fieldset class="border rounded p-3 mb-4" data-fs-repeater="${rootEsc}">
+  <legend class="float-none w-auto px-2 fs-6 fw-semibold">${escapeHtml(label)}</legend>
+  <div class="repeater-rows">
+    <div class="repeater-row border rounded p-3 mb-2 bg-light" data-row-index="0">
+      ${inner}
+    </div>
+  </div>
+  <button type="button" class="btn btn-sm btn-outline-secondary me-2 fs-repeater-remove" style="display:none">Remove row</button>
+  <button type="button" class="btn btn-sm btn-outline-primary fs-repeater-add">Add row</button>
+</fieldset>`;
+  }
+
   if (type === "group") {
     const children = field.children || [];
-    const inner = children.map((c) => generateBootstrapField(c, domIdByKey)).join("\n");
+    const inner = children.map((c) => generateBootstrapField(c, domIdByKey, ctx)).join("\n");
     return `<fieldset class="border rounded p-3 mb-4">
   <legend class="float-none w-auto px-2 fs-6 fw-semibold">${escapeHtml(label)}</legend>
   ${inner}
@@ -77,12 +121,12 @@ function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, strin
   const ariaRequired = required ? `aria-required="true"` : "";
   const autoCompleteAttr = autoComplete ? `autocomplete="${autoComplete}"` : "";
 
-  let control: string;
   switch (type) {
     case "textarea":
-      control = `<textarea
+    case "richtext":
+      return wrapControl(label, required, domId, helpText, `<textarea
           class="form-control"
-          name="${escapeHtml(key)}"
+          name="${nameAttr}"
           id="${domId}"
           rows="3"
           ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ""}
@@ -90,13 +134,17 @@ function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, strin
           ${ariaRequired}
           ${ariaDescribedBy}
           ${autoCompleteAttr}
-        ></textarea>`;
-      break;
+        ></textarea>`);
     case "select": {
       const options = field.constraints?.enum || [];
-      control = `<select
+      return wrapControl(
+        label,
+        required,
+        domId,
+        helpText,
+        `<select
           class="form-select"
-          name="${escapeHtml(key)}"
+          name="${nameAttr}"
           id="${domId}"
           ${required ? "required" : ""}
           ${ariaRequired}
@@ -105,41 +153,152 @@ function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, strin
         >
           <option value="">${escapeHtml(placeholder) || "Select..."}</option>
           ${options.map((o) => `<option value="${escapeHtml(o)}">${escapeHtml(o)}</option>`).join("\n")}
-        </select>`;
-      break;
+        </select>`,
+      );
     }
     case "checkbox":
-      control = `<input
-          class="form-check-input"
-          type="checkbox"
-          name="${escapeHtml(key)}"
-          id="${domId}"
-          value="true"
-          ${ariaRequired}
-          ${ariaDescribedBy}
-        />`;
       return `<div class="form-check mb-3">
-  ${control}
+  <input
+    class="form-check-input"
+    type="checkbox"
+    name="${nameAttr}"
+    id="${domId}"
+    value="true"
+    ${ariaRequired}
+    ${ariaDescribedBy}
+  />
   <label class="form-check-label" for="${domId}">
     ${escapeHtml(label)}${required ? ' <span class="text-danger" aria-hidden="true">*</span>' : ""}
   </label>
   ${helpText ? `<div id="${domId}-help" class="form-text">${escapeHtml(helpText)}</div>` : ""}
   <div id="${domId}-error" class="invalid-feedback d-block" role="alert"></div>
 </div>`;
-    default:
-      control = `<input
+    case "file": {
+      const xui = ui?.["x-ui"];
+      const accept = xui?.accept ? `accept="${escapeHtml(String(xui.accept))}"` : "";
+      const multiple = xui?.multiple ? "multiple" : "";
+      return wrapControl(
+        label,
+        required,
+        domId,
+        helpText,
+        `<input
+          class="form-control"
+          type="file"
+          name="${nameAttr}"
+          id="${domId}"
+          ${accept}
+          ${multiple}
+          ${required ? "required" : ""}
+          ${ariaRequired}
+          ${ariaDescribedBy}
+        />`,
+      );
+    }
+    case "signature": {
+      const hidId = `${domId}_sig`;
+      return wrapControl(
+        label,
+        required,
+        domId,
+        helpText,
+        `<canvas id="${domId}_canvas" width="400" height="160" class="border rounded bg-white mb-2" style="max-width:100%;touch-action:none" data-fs-sig-target="${escapeHtml(hidId)}"></canvas>
+        <input type="hidden" name="${nameAttr}" id="${escapeHtml(hidId)}" />`,
+      );
+    }
+    case "typeahead": {
+      const url = ui?.["x-ui"]?.asyncSource?.url ?? "";
+      const dlId = `${domId}_dl`;
+      return wrapControl(
+        label,
+        required,
+        domId,
+        helpText,
+        `<input
+          class="form-control"
+          type="text"
+          name="${nameAttr}"
+          id="${domId}"
+          list="${escapeHtml(dlId)}"
+          data-typeahead-url="${escapeHtml(url)}"
+          ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ""}
+          ${required ? "required" : ""}
+          ${ariaRequired}
+          ${ariaDescribedBy}
+        />
+        <datalist id="${escapeHtml(dlId)}"></datalist>`,
+      );
+    }
+    case "calculated": {
+      const formula = field["x-calc"] ?? "";
+      return wrapControl(
+        label,
+        required,
+        domId,
+        helpText,
+        `<input
+          class="form-control"
+          type="text"
+          name="${nameAttr}"
+          id="${domId}"
+          readonly
+          data-fs-calculated="${escapeHtml(formula)}"
+          value=""
+          ${ariaRequired}
+          ${ariaDescribedBy}
+        />`,
+      );
+    }
+    case "text":
+    case "email":
+    case "password":
+    case "number":
+    case "date":
+      return wrapControl(
+        label,
+        required,
+        domId,
+        helpText,
+        `<input
           class="form-control"
           type="${escapeHtml(type)}"
-          name="${escapeHtml(key)}"
+          name="${nameAttr}"
           id="${domId}"
           ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ""}
           ${required ? "required" : ""}
           ${ariaRequired}
           ${ariaDescribedBy}
           ${autoCompleteAttr}
-        />`;
+        />`,
+      );
+    case "unknown":
+    default:
+      return wrapControl(
+        label,
+        required,
+        domId,
+        helpText,
+        `<input
+          class="form-control"
+          type="text"
+          name="${nameAttr}"
+          id="${domId}"
+          ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ""}
+          ${required ? "required" : ""}
+          ${ariaRequired}
+          ${ariaDescribedBy}
+        />`,
+      );
   }
+}
 
+function wrapControl(
+  label: string,
+  required: boolean,
+  domId: string,
+  helpText: string | undefined,
+  control: string,
+): string {
   return `<div class="mb-3">
   <label class="form-label" for="${domId}">
     ${escapeHtml(label)}${required ? ' <span class="text-danger" aria-hidden="true">*</span>' : ""}
@@ -233,6 +392,176 @@ function buildFieldIdMapJs(formModel: FormModel): string {
     .join(",\n");
 }
 
+const STATIC_RUNTIME_HELPERS = `
+  function evaluateCalcExpression(formula, values) {
+    if (!formula) return '';
+    var interpolated = formula.replace(/\\{([^}]+)\\}/g, function (_, key) {
+      var k = key.trim();
+      var val = values[k];
+      return val !== undefined && val !== null ? String(val) : '0';
+    });
+    var isArithmetic = /^[\\d\\s+\\-*/().]+$/.test(interpolated);
+    if (isArithmetic) {
+      try {
+        return Function('"use strict"; return (' + interpolated + ')')();
+      } catch (e) {
+        return interpolated;
+      }
+    }
+    return interpolated;
+  }
+
+  function formValuesStringMap(form) {
+    var fd = new FormData(form);
+    var out = {};
+    fd.forEach(function (v, k) {
+      if (typeof v === 'string') out[k] = v;
+    });
+    return out;
+  }
+
+  function updateCalculatedFields(form) {
+    var vals = formValuesStringMap(form);
+    form.querySelectorAll('input[data-fs-calculated]').forEach(function (el) {
+      var f = el.getAttribute('data-fs-calculated') || '';
+      var r = evaluateCalcExpression(f, vals);
+      el.value = typeof r === 'number' && isFinite(r) ? String(r) : String(r);
+    });
+  }
+
+  function syncSignaturePads(form) {
+    form.querySelectorAll('canvas[data-fs-sig-target]').forEach(function (canvas) {
+      var hidId = canvas.getAttribute('data-fs-sig-target');
+      if (!hidId) return;
+      var hid = document.getElementById(hidId);
+      if (hid) hid.value = canvas.toDataURL('image/png');
+    });
+  }
+
+  function wireSignatureDrawing(form) {
+    form.querySelectorAll('canvas[data-fs-sig-target]').forEach(function (canvas) {
+      canvas.addEventListener('pointerdown', function (e) {
+        var g = canvas.getContext('2d');
+        if (!g) return;
+        var rect = canvas.getBoundingClientRect();
+        var drawing = true;
+        g.beginPath();
+        g.strokeStyle = '#111';
+        g.lineWidth = 2;
+        g.moveTo(e.clientX - rect.left, e.clientY - rect.top);
+        function move(ev) {
+          if (!drawing) return;
+          g.lineTo(ev.clientX - rect.left, ev.clientY - rect.top);
+          g.stroke();
+        }
+        function up() {
+          drawing = false;
+          canvas.removeEventListener('pointermove', move);
+        }
+        canvas.setPointerCapture(e.pointerId);
+        canvas.addEventListener('pointermove', move);
+        canvas.addEventListener('pointerup', up, { once: true });
+      });
+    });
+  }
+
+  function setRepeaterRowIndex(rowEl, root, idx) {
+    var prefix = root + '.';
+    rowEl.querySelectorAll('[name]').forEach(function (el) {
+      var name = el.getAttribute('name');
+      if (!name || name.indexOf(prefix) !== 0) return;
+      var tail = name.slice(prefix.length);
+      var dot = tail.indexOf('.');
+      if (dot === -1) return;
+      var first = tail.slice(0, dot);
+      if (!/^\\d+$/.test(first)) return;
+      el.setAttribute('name', prefix + idx + tail.slice(dot));
+    });
+    rowEl.querySelectorAll('[id]').forEach(function (el) {
+      var id = el.getAttribute('id');
+      if (id) el.setAttribute('id', id.replace(/_r\\d+$/, '_r' + idx));
+    });
+    rowEl.querySelectorAll('[for]').forEach(function (el) {
+      var f = el.getAttribute('for');
+      if (f) el.setAttribute('for', f.replace(/_r\\d+$/, '_r' + idx));
+    });
+  }
+
+  function initRepeaters(form) {
+    form.querySelectorAll('[data-fs-repeater]').forEach(function (fs) {
+      var root = fs.getAttribute('data-fs-repeater');
+      if (!root) return;
+      var rowsC = fs.querySelector('.repeater-rows');
+      var template = rowsC ? rowsC.querySelector('.repeater-row') : null;
+      var addBtn = fs.querySelector('.fs-repeater-add');
+      var remBtn = fs.querySelector('.fs-repeater-remove');
+      if (!rowsC || !template || !addBtn) return;
+
+      function refreshRemoveButtons() {
+        var rows = rowsC.querySelectorAll('.repeater-row');
+        rows.forEach(function (row, i) {
+          row.setAttribute('data-row-index', String(i));
+          setRepeaterRowIndex(row, root, i);
+        });
+        if (remBtn) remBtn.style.display = rows.length > 1 ? 'inline-block' : 'none';
+      }
+
+      addBtn.addEventListener('click', function () {
+        var clone = template.cloneNode(true);
+        var n = rowsC.querySelectorAll('.repeater-row').length;
+        setRepeaterRowIndex(clone, root, n);
+        rowsC.appendChild(clone);
+        wireSignatureDrawing(clone);
+        refreshRemoveButtons();
+      });
+
+      if (remBtn) {
+        remBtn.addEventListener('click', function () {
+          var rows = rowsC.querySelectorAll('.repeater-row');
+          if (rows.length <= 1) return;
+          rows[rows.length - 1].remove();
+          refreshRemoveButtons();
+        });
+      }
+
+      refreshRemoveButtons();
+    });
+  }
+
+  function initTypeaheads(form) {
+    var timers = {};
+    form.querySelectorAll('input[data-typeahead-url]').forEach(function (input) {
+      var urlTpl = input.getAttribute('data-typeahead-url') || '';
+      var listId = input.getAttribute('list');
+      if (!listId || !urlTpl) return;
+      var dl = document.getElementById(listId);
+      if (!dl) return;
+      input.addEventListener('input', function () {
+        var key = input.id || listId;
+        clearTimeout(timers[key]);
+        var q = input.value.trim();
+        timers[key] = setTimeout(function () {
+          var url = urlTpl.split('{query}').join(encodeURIComponent(q));
+          fetch(url)
+            .then(function (r) {
+              return r.json();
+            })
+            .then(function (data) {
+              var arr = Array.isArray(data) ? data : [];
+              dl.innerHTML = '';
+              arr.slice(0, 50).forEach(function (item) {
+                var opt = document.createElement('option');
+                opt.value = typeof item === 'string' ? item : (item.label || item.value || String(item));
+                dl.appendChild(opt);
+              });
+            })
+            .catch(function () {});
+        }, 300);
+      });
+    });
+  }
+`;
+
 function generateAppJs(
   formModel: FormModel,
   wiring?: StaticGeneratorWiring & { fieldTypesJson: string },
@@ -261,12 +590,23 @@ function generateAppJs(
   var form = document.getElementById("main-form");
   if (!form) return;
 
+${STATIC_RUNTIME_HELPERS}
+
+  wireSignatureDrawing(form);
+  initRepeaters(form);
+  initTypeaheads(form);
+  form.addEventListener("input", function () {
+    updateCalculatedFields(form);
+  });
+  updateCalculatedFields(form);
+
   var FIELD_ID_MAP = {
 ${fieldMapLines}
   };
 
   form.addEventListener("submit", async function (e) {
     e.preventDefault();
+    syncSignaturePads(form);
     var fd = new FormData(form);
     var data = Object.fromEntries(fd.entries());
 
@@ -311,9 +651,7 @@ export function collectFieldTypeMap(formModel: FormModel): Record<string, string
   const walk = (fields: FieldModel[]) => {
     for (const field of fields) {
       map[field.key] = field.type;
-      if (field.children && field.children.length > 0) {
-        walk(field.children);
-      }
+      if (field.children?.length) walk(field.children);
     }
   };
   walk(formModel.fields);
@@ -372,6 +710,13 @@ export function generateStaticBootstrapFiles(
   const readme = `# ${escapeHtml(title)} — static form
 
 Generated HTML + Bootstrap 5 + vanilla JavaScript (no build step).
+
+## Advanced fields
+
+- **File uploads** are sent as **Base64 / data URL strings inside JSON** when wired POST is enabled. Keep files small; very large payloads may fail (browser/server limits).
+- **Rich text** is a plain \`<textarea>\` (HTML string). Add a WYSIWYG library if you need an editor.
+- **Typeahead** calls \`data-typeahead-url\` with \`{query}\` replaced; your API must allow **CORS** from this origin.
+- **Repeater** uses indexed field names (\`root.0.child\`, \`root.1.child\`, …). Use **Add row** / **Remove row** (last row removed).
 
 ## Run locally
 

--- a/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
+++ b/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
@@ -1,0 +1,401 @@
+/**
+ * Static HTML + Bootstrap 5 + vanilla JS from FormModel.
+ * Field markup aligned with react-generator semantics.
+ */
+
+import { buildVanillaWiredSubmitReplacement } from "@formsync/formgen-shared";
+import type { FieldModel, FormModel } from "../types";
+
+const AUTO_COMPLETE_MAP: Record<string, string> = {
+  name: "name",
+  firstName: "given-name",
+  lastName: "family-name",
+  email: "email",
+  phone: "tel",
+  mobile: "tel",
+  password: "current-password",
+  newPassword: "new-password",
+  street: "street-address",
+  city: "address-level2",
+  state: "address-level1",
+  zip: "postal-code",
+  country: "country-name",
+  organisation: "organization",
+  company: "organization",
+};
+
+export interface StaticGeneratorWiring {
+  apiBaseUrl: string;
+  apiPath: string;
+}
+
+function escapeHtml(text: string): string {
+  const map: Record<string, string> = {
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#039;",
+  };
+  return text.replace(/[&<>"']/g, (m) => map[m]);
+}
+
+function collectAllFields(fields: FieldModel[]): FieldModel[] {
+  const result: FieldModel[] = [];
+  for (const f of fields) {
+    if (f.type === "group" && f.children && f.children.length > 0) {
+      result.push(...collectAllFields(f.children));
+    } else {
+      result.push(f);
+    }
+  }
+  return result;
+}
+
+function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, string>): string {
+  const { id, key, type, label, required, ui } = field;
+  const domId = domIdByKey.get(key) ?? id;
+  const explicitPlaceholder = ui?.placeholder;
+  const computedPlaceholder = explicitPlaceholder ?? `Enter ${label.toLowerCase()}...`;
+  const placeholder = type === "date" ? "" : computedPlaceholder;
+  const helpText = ui?.helpText;
+  const autoComplete = AUTO_COMPLETE_MAP[key] ?? "";
+
+  if (type === "group") {
+    const children = field.children || [];
+    const inner = children.map((c) => generateBootstrapField(c, domIdByKey)).join("\n");
+    return `<fieldset class="border rounded p-3 mb-4">
+  <legend class="float-none w-auto px-2 fs-6 fw-semibold">${escapeHtml(label)}</legend>
+  ${inner}
+</fieldset>`;
+  }
+
+  const describedByParts: string[] = [];
+  if (helpText) describedByParts.push(`${domId}-help`);
+  describedByParts.push(`${domId}-error`);
+  const ariaDescribedBy = `aria-describedby="${describedByParts.join(" ")}"`;
+  const ariaRequired = required ? `aria-required="true"` : "";
+  const autoCompleteAttr = autoComplete ? `autocomplete="${autoComplete}"` : "";
+
+  let control: string;
+  switch (type) {
+    case "textarea":
+      control = `<textarea
+          class="form-control"
+          name="${escapeHtml(key)}"
+          id="${domId}"
+          rows="3"
+          ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ""}
+          ${required ? "required" : ""}
+          ${ariaRequired}
+          ${ariaDescribedBy}
+          ${autoCompleteAttr}
+        ></textarea>`;
+      break;
+    case "select": {
+      const options = field.constraints?.enum || [];
+      control = `<select
+          class="form-select"
+          name="${escapeHtml(key)}"
+          id="${domId}"
+          ${required ? "required" : ""}
+          ${ariaRequired}
+          ${ariaDescribedBy}
+          ${autoCompleteAttr}
+        >
+          <option value="">${escapeHtml(placeholder) || "Select..."}</option>
+          ${options.map((o) => `<option value="${escapeHtml(o)}">${escapeHtml(o)}</option>`).join("\n")}
+        </select>`;
+      break;
+    }
+    case "checkbox":
+      control = `<input
+          class="form-check-input"
+          type="checkbox"
+          name="${escapeHtml(key)}"
+          id="${domId}"
+          value="true"
+          ${ariaRequired}
+          ${ariaDescribedBy}
+        />`;
+      return `<div class="form-check mb-3">
+  ${control}
+  <label class="form-check-label" for="${domId}">
+    ${escapeHtml(label)}${required ? ' <span class="text-danger" aria-hidden="true">*</span>' : ""}
+  </label>
+  ${helpText ? `<div id="${domId}-help" class="form-text">${escapeHtml(helpText)}</div>` : ""}
+  <div id="${domId}-error" class="invalid-feedback d-block" role="alert"></div>
+</div>`;
+    default:
+      control = `<input
+          class="form-control"
+          type="${escapeHtml(type)}"
+          name="${escapeHtml(key)}"
+          id="${domId}"
+          ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ""}
+          ${required ? "required" : ""}
+          ${ariaRequired}
+          ${ariaDescribedBy}
+          ${autoCompleteAttr}
+        />`;
+  }
+
+  return `<div class="mb-3">
+  <label class="form-label" for="${domId}">
+    ${escapeHtml(label)}${required ? ' <span class="text-danger" aria-hidden="true">*</span>' : ""}
+  </label>
+  ${control}
+  ${helpText ? `<div id="${domId}-help" class="form-text">${escapeHtml(helpText)}</div>` : ""}
+  <div id="${domId}-error" class="invalid-feedback d-block" role="alert"></div>
+</div>`;
+}
+
+function buildFormBody(formModel: FormModel, domIdByKey: Map<string, string>): string {
+  const { fields, layout, submit } = formModel;
+  const orderedFields = layout.order
+    .map((fid) => fields.find((f) => f.id === fid))
+    .filter((f): f is FieldModel => !!f);
+
+  const hasFields = orderedFields.length > 0;
+  const submitText = submit?.text || "Submit";
+  const submitColor = submit?.color;
+
+  const btnStyle = submitColor ? ` style="background-color:${escapeHtml(submitColor)};border-color:${escapeHtml(submitColor)}"` : "";
+
+  if (!hasFields) {
+    return `<p class="text-muted">Form is empty.</p>`;
+  }
+
+  if (layout.steps && layout.steps.length > 0) {
+    const sections = layout.steps.map((step, stepIdx) => {
+      const stepFields = orderedFields.filter(
+        (f) => f.stepIndex === stepIdx || f.stepIndex === undefined,
+      );
+      const inner = stepFields.map((f) => generateBootstrapField(f, domIdByKey)).join("\n");
+      return `<div class="card mb-4">
+  <div class="card-header fw-semibold"><span class="badge bg-primary me-2">${stepIdx + 1}</span>${escapeHtml(step.title)}</div>
+  <div class="card-body">
+    ${inner}
+  </div>
+</div>`;
+    });
+    return `<form id="main-form" novalidate>
+  ${sections.join("\n")}
+  <button type="submit" class="btn btn-primary"${btnStyle}>${escapeHtml(submitText)}</button>
+</form>`;
+  }
+
+  const fieldHtml = orderedFields.map((f) => generateBootstrapField(f, domIdByKey)).join("\n");
+  return `<form id="main-form" novalidate>
+  ${fieldHtml}
+  <button type="submit" class="btn btn-primary"${btnStyle}>${escapeHtml(submitText)}</button>
+</form>`;
+}
+
+function generateThemeCss(formModel: FormModel): string {
+  const { colors, typography, radius } = formModel.theme;
+  return `/* Theme derived from FormModel */
+:root {
+  --bs-primary: ${colors.primary};
+  --bs-body-bg: ${colors.background};
+  --bs-body-color: ${colors.text};
+  --bs-border-color: ${colors.border};
+  --fs-form-radius: ${radius}px;
+  --fs-font-family: ${typography.fontFamily};
+  --fs-base-font-size: ${typography.baseFontSize}px;
+}
+
+body {
+  font-family: var(--fs-font-family);
+  font-size: var(--fs-base-font-size);
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
+}
+
+.form-control:focus {
+  border-color: ${colors.primary};
+  box-shadow: 0 0 0 0.2rem color-mix(in srgb, ${colors.primary} 25%, transparent);
+}
+`;
+}
+
+function buildFieldIdMapJs(formModel: FormModel): string {
+  const orderedFields = formModel.layout.order
+    .map((fid) => formModel.fields.find((f) => f.id === fid))
+    .filter((f): f is FieldModel => !!f);
+  const domIdByKey = new Map<string, string>();
+  collectAllFields(orderedFields).forEach((f, i) => {
+    domIdByKey.set(f.key, `field_${i + 1}`);
+  });
+  const allFields = collectAllFields(orderedFields);
+  return allFields
+    .map((f) => `    '${f.key.replace(/'/g, "\\'")}': '${domIdByKey.get(f.key) ?? f.id}'`)
+    .join(",\n");
+}
+
+function generateAppJs(
+  formModel: FormModel,
+  wiring?: StaticGeneratorWiring & { fieldTypesJson: string },
+): string {
+  const fieldMapLines = buildFieldIdMapJs(formModel);
+
+  const submitBody = wiring
+    ? buildVanillaWiredSubmitReplacement({
+        serializedFieldTypes: wiring.fieldTypesJson,
+        apiBaseUrl: wiring.apiBaseUrl,
+        apiPath: wiring.apiPath,
+      })
+    : `/* FORMSYNC_API_SUBMIT_START */
+    console.log("Form submitted:", Object.fromEntries(new FormData(form)));
+    /* FORMSYNC_API_SUBMIT_END */`;
+
+  const submitIndented = submitBody
+    .split("\n")
+    .map((line) => "    " + line)
+    .join("\n");
+
+  return `/**
+ * Generated by FormSync static-frontend-generator — do not edit by hand.
+ */
+(function () {
+  var form = document.getElementById("main-form");
+  if (!form) return;
+
+  var FIELD_ID_MAP = {
+${fieldMapLines}
+  };
+
+  form.addEventListener("submit", async function (e) {
+    e.preventDefault();
+    var fd = new FormData(form);
+    var data = Object.fromEntries(fd.entries());
+
+    var errs = validate(data);
+    var errorKeys = Object.keys(errs);
+    if (errorKeys.length > 0) {
+      var statusEl = document.getElementById("form-status");
+      if (statusEl) {
+        statusEl.textContent =
+          errorKeys.length === 1
+            ? "1 error found. Please review the highlighted field."
+            : errorKeys.length + " errors found. Please review the highlighted fields.";
+      }
+      var firstKey = errorKeys[0];
+      var firstId = FIELD_ID_MAP[firstKey];
+      if (firstId) {
+        var el = document.getElementById(firstId);
+        if (el) {
+          el.focus();
+          el.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
+      }
+      return;
+    }
+
+    var statusClear = document.getElementById("form-status");
+    if (statusClear) statusClear.textContent = "";
+
+${submitIndented}
+  });
+
+  function validate(data) {
+    var errs = {};
+    return errs;
+  }
+})();
+`;
+}
+
+export function collectFieldTypeMap(formModel: FormModel): Record<string, string> {
+  const map: Record<string, string> = {};
+  const walk = (fields: FieldModel[]) => {
+    for (const field of fields) {
+      map[field.key] = field.type;
+      if (field.children && field.children.length > 0) {
+        walk(field.children);
+      }
+    }
+  };
+  walk(formModel.fields);
+  return map;
+}
+
+export function generateStaticBootstrapFiles(
+  formModel: FormModel,
+  wiring?: StaticGeneratorWiring,
+): Record<string, string> {
+  const wiringWithTypes =
+    wiring &&
+    ({
+      ...wiring,
+      fieldTypesJson: JSON.stringify(collectFieldTypeMap(formModel), null, 2),
+    } as StaticGeneratorWiring & { fieldTypesJson: string });
+
+  const orderedFields = formModel.layout.order
+    .map((fid) => formModel.fields.find((f) => f.id === fid))
+    .filter((f): f is FieldModel => !!f);
+
+  const domIdByKey = new Map<string, string>();
+  collectAllFields(orderedFields).forEach((f, i) => {
+    domIdByKey.set(f.key, `field_${i + 1}`);
+  });
+
+  const title = formModel.meta?.title || formModel.name;
+  const description = formModel.meta?.description;
+
+  const bodyInner = buildFormBody(formModel, domIdByKey);
+
+  const appJs = generateAppJs(formModel, wiringWithTypes || undefined);
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${escapeHtml(title)}</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" />
+  <link rel="stylesheet" href="css/theme.css" />
+</head>
+<body>
+  <main class="container py-4">
+    <div id="form-status" class="text-danger mb-3" role="status" aria-live="polite"></div>
+    <h1 class="h3 mb-2">${escapeHtml(title)}</h1>
+    ${description ? `<p class="text-muted mb-4">${escapeHtml(description)}</p>` : ""}
+    ${bodyInner}
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>
+`;
+
+  const readme = `# ${escapeHtml(title)} — static form
+
+Generated HTML + Bootstrap 5 + vanilla JavaScript (no build step).
+
+## Run locally
+
+Use any static file server from this folder, for example:
+
+\`\`\`bash
+npx serve .
+\`\`\`
+
+Then open the printed URL in your browser.
+
+## API wiring
+
+${
+    wiring
+      ? `This bundle is configured to POST JSON to **${escapeHtml(wiring.apiBaseUrl)}${escapeHtml(wiring.apiPath)}**. Edit \`js/app.js\` if your backend runs elsewhere (ensure CORS allows your origin).`
+      : `Wire your backend by replacing the placeholder in \`js/app.js\` between the FORMSYNC markers, or regenerate from FormSync with fullstack export.`
+  }
+`;
+
+  return {
+    "index.html": html,
+    "css/theme.css": generateThemeCss(formModel),
+    "js/app.js": appJs,
+    "README.md": readme,
+  };
+}

--- a/formsync/services/static-frontend-generator/src/server.ts
+++ b/formsync/services/static-frontend-generator/src/server.ts
@@ -1,0 +1,108 @@
+/**
+ * static-frontend-generator — HTML + Bootstrap + vanilla JS from FormModel
+ *
+ * Port 3017 (default)
+ */
+
+import * as path from "path";
+import * as dotenv from "dotenv";
+dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
+
+import express from "express";
+import cors from "cors";
+import * as os from "os";
+import * as crypto from "crypto";
+import * as fs from "fs-extra";
+import archiver from "archiver";
+import type { FormModel } from "./types";
+import {
+  generateStaticBootstrapFiles,
+  type StaticGeneratorWiring,
+} from "./generators/static-bootstrap-generator";
+
+const app = express();
+const port = process.env.STATIC_FRONTEND_GENERATOR_PORT || 3017;
+
+app.use(cors());
+app.use(express.json({ limit: "5mb" }));
+
+/**
+ * POST /generate
+ * Body: { formModel: FormModel, preview?: boolean, wiring?: { apiBaseUrl, apiPath } }
+ * - preview true → JSON { success, files: [{ path, content }] }
+ * - preview false/absent → application/zip
+ */
+app.post("/generate", async (req, res) => {
+  const {
+    formModel,
+    preview,
+    wiring,
+  }: {
+    formModel?: FormModel;
+    preview?: boolean;
+    wiring?: StaticGeneratorWiring;
+  } = req.body;
+
+  if (!formModel) {
+    return res.status(400).json({ error: "formModel is required" });
+  }
+
+  const requestId = crypto.randomUUID();
+  const tempDir = path.join(os.tmpdir(), `formsync-static-fe-${requestId}`);
+
+  try {
+    const filesRecord = generateStaticBootstrapFiles(formModel, wiring);
+
+    if (preview) {
+      const files = Object.entries(filesRecord).map(([p, content]) => ({
+        path: p,
+        content,
+      }));
+      res.json({ success: true, requestId, files });
+      return;
+    }
+
+    await fs.ensureDir(tempDir);
+    for (const [relPath, content] of Object.entries(filesRecord)) {
+      const fullPath = path.join(tempDir, relPath);
+      await fs.ensureDir(path.dirname(fullPath));
+      await fs.writeFile(fullPath, content, "utf8");
+    }
+
+    const slug = String(formModel.name || "form")
+      .toLowerCase()
+      .replace(/\s+/g, "-");
+    res.attachment(`${slug}-html-bootstrap.zip`);
+    res.setHeader("Content-Type", "application/zip");
+
+    const archive = archiver("zip", { zlib: { level: 9 } });
+    archive.pipe(res);
+    archive.directory(tempDir, false);
+    archive.finalize();
+
+    res.on("finish", () => {
+      fs.remove(tempDir).catch(() => {});
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[${requestId}] Generate failed:`, message);
+    if (!res.headersSent) {
+      res.status(500).json({ error: "Generation failed", message });
+    }
+    fs.remove(tempDir).catch(() => {});
+  }
+});
+
+app.get("/health", (_req, res) => {
+  res.json({
+    status: "ok",
+    service: "static-frontend-generator",
+    uptime: process.uptime(),
+  });
+});
+
+app.listen(port, () => {
+  console.log(`🚀 static-frontend-generator at http://localhost:${port}`);
+  console.log(`   POST /generate — FormModel → ZIP or JSON files (preview)`);
+  console.log(`   GET  /health`);
+});

--- a/formsync/services/static-frontend-generator/src/types/index.ts
+++ b/formsync/services/static-frontend-generator/src/types/index.ts
@@ -1,0 +1,113 @@
+/**
+ * Mirrors formgen-service FormModel (inlined for microservice independence).
+ */
+
+export type FieldType =
+  | "text"
+  | "email"
+  | "password"
+  | "number"
+  | "select"
+  | "checkbox"
+  | "textarea"
+  | "date"
+  | "group"
+  | "unknown";
+
+export interface FieldConstraints {
+  min?: number;
+  max?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  enum?: string[];
+  [key: string]: string | number | boolean | string[] | undefined;
+}
+
+export interface FieldStyleOverrides {
+  labelColor?: string;
+  inputTextColor?: string;
+  borderColor?: string;
+  backgroundColor?: string;
+  focusColor?: string;
+}
+
+export interface FieldUIConfig {
+  placeholder?: string;
+  helpText?: string;
+  hidden?: boolean;
+  disabled?: boolean;
+  style?: Record<string, string | number>;
+  styleOverrides?: FieldStyleOverrides;
+  [key: string]:
+    | string
+    | number
+    | boolean
+    | Record<string, unknown>
+    | FieldStyleOverrides
+    | undefined;
+}
+
+export interface FieldModel {
+  id: string;
+  key: string;
+  type: FieldType;
+  label: string;
+  required: boolean;
+  defaultValue?: string | number | boolean | null;
+  constraints?: FieldConstraints;
+  ui?: FieldUIConfig;
+  children?: FieldModel[];
+  stepIndex?: number;
+}
+
+export interface ThemeColors {
+  primary: string;
+  background: string;
+  surface: string;
+  text: string;
+  muted: string;
+  border: string;
+  error: string;
+  inputBackground: string;
+}
+
+export interface ThemeConfig {
+  mode: "light" | "dark";
+  density: "compact" | "normal" | "comfortable";
+  colors: ThemeColors;
+  schemes?: {
+    light: ThemeColors;
+    dark: ThemeColors;
+  };
+  typography: {
+    fontFamily: string;
+    baseFontSize: number;
+  };
+  radius: number;
+  primaryColor?: string;
+}
+
+export interface LayoutConfig {
+  order: string[];
+  steps?: Array<{ id: string; title: string }>;
+}
+
+export interface SubmitConfig {
+  text: string;
+  color?: string;
+}
+
+export interface FormModel {
+  id: string;
+  name: string;
+  version: string;
+  meta?: {
+    title?: string;
+    description?: string;
+  };
+  theme: ThemeConfig;
+  layout: LayoutConfig;
+  fields: FieldModel[];
+  submit?: SubmitConfig;
+}

--- a/formsync/services/static-frontend-generator/src/types/index.ts
+++ b/formsync/services/static-frontend-generator/src/types/index.ts
@@ -1,113 +1,22 @@
 /**
- * Mirrors formgen-service FormModel (inlined for microservice independence).
+ * Re-export canonical FormModel types from @formsync/form-types.
  */
 
-export type FieldType =
-  | "text"
-  | "email"
-  | "password"
-  | "number"
-  | "select"
-  | "checkbox"
-  | "textarea"
-  | "date"
-  | "group"
-  | "unknown";
-
-export interface FieldConstraints {
-  min?: number;
-  max?: number;
-  minLength?: number;
-  maxLength?: number;
-  pattern?: string;
-  enum?: string[];
-  [key: string]: string | number | boolean | string[] | undefined;
-}
-
-export interface FieldStyleOverrides {
-  labelColor?: string;
-  inputTextColor?: string;
-  borderColor?: string;
-  backgroundColor?: string;
-  focusColor?: string;
-}
-
-export interface FieldUIConfig {
-  placeholder?: string;
-  helpText?: string;
-  hidden?: boolean;
-  disabled?: boolean;
-  style?: Record<string, string | number>;
-  styleOverrides?: FieldStyleOverrides;
-  [key: string]:
-    | string
-    | number
-    | boolean
-    | Record<string, unknown>
-    | FieldStyleOverrides
-    | undefined;
-}
-
-export interface FieldModel {
-  id: string;
-  key: string;
-  type: FieldType;
-  label: string;
-  required: boolean;
-  defaultValue?: string | number | boolean | null;
-  constraints?: FieldConstraints;
-  ui?: FieldUIConfig;
-  children?: FieldModel[];
-  stepIndex?: number;
-}
-
-export interface ThemeColors {
-  primary: string;
-  background: string;
-  surface: string;
-  text: string;
-  muted: string;
-  border: string;
-  error: string;
-  inputBackground: string;
-}
-
-export interface ThemeConfig {
-  mode: "light" | "dark";
-  density: "compact" | "normal" | "comfortable";
-  colors: ThemeColors;
-  schemes?: {
-    light: ThemeColors;
-    dark: ThemeColors;
-  };
-  typography: {
-    fontFamily: string;
-    baseFontSize: number;
-  };
-  radius: number;
-  primaryColor?: string;
-}
-
-export interface LayoutConfig {
-  order: string[];
-  steps?: Array<{ id: string; title: string }>;
-}
-
-export interface SubmitConfig {
-  text: string;
-  color?: string;
-}
-
-export interface FormModel {
-  id: string;
-  name: string;
-  version: string;
-  meta?: {
-    title?: string;
-    description?: string;
-  };
-  theme: ThemeConfig;
-  layout: LayoutConfig;
-  fields: FieldModel[];
-  submit?: SubmitConfig;
-}
+export type {
+  FieldType,
+  FieldModel,
+  FieldConstraints,
+  FieldUIConfig,
+  FieldXUI,
+  AsyncSourceConfig,
+  FieldConditions,
+  ConditionRule,
+  ConditionOperator,
+  FieldStyleOverrides,
+  ThemeColors,
+  ThemeConfig,
+  LayoutConfig,
+  FormStep,
+  SubmitConfig,
+  FormModel,
+} from "@formsync/form-types";

--- a/formsync/services/static-frontend-generator/tsconfig.json
+++ b/formsync/services/static-frontend-generator/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
This pull request introduces support for generating and downloading a static HTML + Bootstrap frontend, in addition to existing React frontend options. It adds a new `static-frontend-generator` service, updates the frontend UI to allow users to select between frontend stacks, and enables downloading the static HTML frontend directly. The changes span Docker, frontend code, and supporting infrastructure.

**New static frontend generation support:**

- Added a new `static-frontend-generator` service to `docker-compose.yml`, including build configuration, environment variables, port mapping (`3017`), and health checks. This service is now part of the overall system and is started with other generators. [[1]](diffhunk://#diff-eb89abe93ed73ee40fc89c31ff7be35780dfa1c2f8e0befa1fe58b0f96692c7bR14) [[2]](diffhunk://#diff-eb89abe93ed73ee40fc89c31ff7be35780dfa1c2f8e0befa1fe58b0f96692c7bR44) [[3]](diffhunk://#diff-eb89abe93ed73ee40fc89c31ff7be35780dfa1c2f8e0befa1fe58b0f96692c7bR55) [[4]](diffhunk://#diff-eb89abe93ed73ee40fc89c31ff7be35780dfa1c2f8e0befa1fe58b0f96692c7bR265-R288) [[5]](diffhunk://#diff-eb89abe93ed73ee40fc89c31ff7be35780dfa1c2f8e0befa1fe58b0f96692c7bR315-R316) [[6]](diffhunk://#diff-9e7734cd952301922801a7da63c3264abfd2d40a239c7aee8723be627905b842R7-R16)
- Updated Nginx and Vite proxy configurations to route `/static-frontend` requests to the gateway, enabling frontend access to the new service. [[1]](diffhunk://#diff-a1fe64677529997a32c19f196befbc97ca4f607d8f3577d0abc1a5cfa29497d8R103-R113) [[2]](diffhunk://#diff-407368107cf7f8494b163ae82ad7fdf1e6b30624c0d5f6fb49769cca75ce503dR57-R60)

**Frontend UI enhancements:**

- Introduced a new `FrontendStackSelector` React component, allowing users to choose between "React (Vite)" and "HTML + Bootstrap" as the frontend stack. This selector is integrated into the generated code page. [[1]](diffhunk://#diff-b3e36a4d93d79654144bb049a3ea40ad906fc577c347d90b7a2a8eb8eb52d32cR1-R105) [[2]](diffhunk://#diff-448c1307a35aa53e6e1bda98b7a4b557592f7222216a8326f329921ddc551a88L405-R440) [[3]](diffhunk://#diff-448c1307a35aa53e6e1bda98b7a4b557592f7222216a8326f329921ddc551a88R455-R480)
- Added a "Download HTML frontend only" button, which triggers the generation and download of a static HTML + Bootstrap ZIP via the new service. The download state is tracked and users are notified of success or errors. [[1]](diffhunk://#diff-448c1307a35aa53e6e1bda98b7a4b557592f7222216a8326f329921ddc551a88R147-R148) [[2]](diffhunk://#diff-448c1307a35aa53e6e1bda98b7a4b557592f7222216a8326f329921ddc551a88R160-R167) [[3]](diffhunk://#diff-448c1307a35aa53e6e1bda98b7a4b557592f7222216a8326f329921ddc551a88R392-R410) [[4]](diffhunk://#diff-448c1307a35aa53e6e1bda98b7a4b557592f7222216a8326f329921ddc551a88R455-R480)

**API and service integration:**

- Extended the `generationService` to support specifying the frontend stack in fullstack ZIP downloads and to provide a new `downloadStaticFrontendZip` method for static frontend downloads. The file naming logic now reflects the selected frontend stack. [[1]](diffhunk://#diff-76f1572e02792604e80fcff5e3feb8ee08a525b2913eac035d6119e43947d1c1R9-R10) [[2]](diffhunk://#diff-76f1572e02792604e80fcff5e3feb8ee08a525b2913eac035d6119e43947d1c1R151-R163) [[3]](diffhunk://#diff-76f1572e02792604e80fcff5e3feb8ee08a525b2913eac035d6119e43947d1c1L177-R225)
- Updated the code generation flow to pass the selected frontend stack and persist it in session storage, ensuring consistent user experience across sessions.

**Dependency and workspace setup:**

- Added `@formsync/form-types` as a local dependency in the frontend, and updated the workspace and Dockerfile setup to ensure it is built and available for TypeScript types. [[1]](diffhunk://#diff-35466b83e62d7d41d2aea35f840e38269a6d7f7bdef0c8c1c31351466b7b668cR15) [[2]](diffhunk://#diff-3acca41fdc179124e16eb5c8dfc8ae821f859d6d2d1b7f286765c6d77b9d5c3cR9-R16) [[3]](diffhunk://#diff-9e7734cd952301922801a7da63c3264abfd2d40a239c7aee8723be627905b842R7-R16)

**Other improvements:**

- Refactored code in `GeneratedCodePage` to support the new frontend stack options and to clean up state handling for code generation and downloads. [[1]](diffhunk://#diff-448c1307a35aa53e6e1bda98b7a4b557592f7222216a8326f329921ddc551a88L184-R204) [[2]](diffhunk://#diff-448c1307a35aa53e6e1bda98b7a4b557592f7222216a8326f329921ddc551a88L225-R239) [[3]](diffhunk://#diff-448c1307a35aa53e6e1bda98b7a4b557592f7222216a8326f329921ddc551a88L266) [[4]](diffhunk://#diff-448c1307a35aa53e6e1bda98b7a4b557592f7222216a8326f329921ddc551a88R18-R22)

These changes collectively enable users to generate, preview, and download both React and static HTML frontends for their forms, improving flexibility and supporting more deployment scenarios.