### PR TITLE
133 add html bootstrap javascript frontend code generation support

### DIFF
--- a/formsync/frontend/src/builder/BuilderLayout.tsx
+++ b/formsync/frontend/src/builder/BuilderLayout.tsx
@@ -5,13 +5,46 @@ import { Canvas } from "./Canvas";
 import { RightPanel } from "./RightPanel";
 import { WizardControls } from "./WizardControls";
 import { useBuilder, BuilderExportPayload, FORMSYNC_BUILDER_EXPORT_FORM_KEY } from "../context/BuilderContext";
-import { generationService, BackendLanguage } from "../services/generationService";
+import {
+  generationService,
+  BackendLanguage,
+  type FrontendStack,
+} from "../services/generationService";
 import { formModelToJsonSchema, validateBuilderJsonSchema } from "../types";
 import { FlowDiagram } from "../components/shared/FlowDiagram";
 import { Undo2 } from "lucide-react";
 import { Navbar } from "../components/layout/Navbar";
 import { Button } from "../components/ui/button";
 import { toast } from "sonner";
+
+function readFrontendStackFromSession(): FrontendStack | undefined {
+  try {
+    const fe = sessionStorage.getItem("formsync_frontend_stack");
+    if (fe === "react" || fe === "htmlBootstrap") return fe;
+  } catch {
+    /* ignore */
+  }
+  return undefined;
+}
+
+function appendStackPreferences(p: URLSearchParams): void {
+  try {
+    const be = sessionStorage.getItem(
+      "formsync_backend_language",
+    ) as BackendLanguage | null;
+    if (
+      be === "nodeExpress" ||
+      be === "springBoot" ||
+      be === "dotnetWebApi"
+    ) {
+      p.set("backendLanguage", be);
+    }
+    const fe = readFrontendStackFromSession();
+    if (fe) p.set("frontendStack", fe);
+  } catch {
+    /* ignore */
+  }
+}
 
 export const BuilderLayout: React.FC = () => {
   const { state, dispatch, canUndo } = useBuilder();
@@ -102,8 +135,16 @@ export const BuilderLayout: React.FC = () => {
           /* ignore */
         }
 
-        navigate(`/generated?schemaId=${state.schemaId}`, {
-          state: { schema: synced, formModel: state.form },
+        const genQs = new URLSearchParams();
+        genQs.set("schemaId", state.schemaId);
+        appendStackPreferences(genQs);
+        const fe = readFrontendStackFromSession();
+        navigate(`/generated?${genQs.toString()}`, {
+          state: {
+            schema: synced,
+            formModel: state.form,
+            ...(fe ? { frontendStack: fe } : {}),
+          },
         });
         return;
       } else {
@@ -121,12 +162,17 @@ export const BuilderLayout: React.FC = () => {
           );
           sessionStorage.removeItem("formsync_schema_raw");
           if (result.success && result.data) {
-            navigate("/generated", {
+            const fe = readFrontendStackFromSession();
+            const genQs = new URLSearchParams();
+            appendStackPreferences(genQs);
+            const qs = genQs.toString();
+            navigate(qs ? `/generated?${qs}` : "/generated", {
               state: {
                 generatedCode: result.data,
                 schema,
                 formModel: state.form,
                 backendLanguage: storedBackend,
+                ...(fe ? { frontendStack: fe } : {}),
               },
             });
             return;

--- a/formsync/frontend/src/builder/BuilderLayout.tsx
+++ b/formsync/frontend/src/builder/BuilderLayout.tsx
@@ -209,32 +209,30 @@ export const BuilderLayout: React.FC = () => {
           <LeftPanel />
         </aside>
 
-        {/* ── Center: stepper → wizard bar → canvas ── */}
+        {/* ── Center: pipeline strip + wizard + canvas (single chrome band) ── */}
         <main className="builder-canvas-col">
-          {/* Progress stepper — contained in canvas column */}
-          <div className="canvas-stepper">
-            <FlowDiagram stages={stages} />
-          </div>
-
-          {/* Wizard controls + Undo on the same bar */}
-          <div className="canvas-toolbar">
-            <WizardControls />
-            <div className="canvas-toolbar-actions">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => dispatch({ type: "UNDO" })}
-                disabled={!canUndo}
-                className="gap-1.5 text-neutral-500 h-7 px-2.5 text-xs"
-                title="Undo"
-              >
-                <Undo2 className="h-3.5 w-3.5" />
-                Undo
-              </Button>
+          <div className="builder-canvas-header">
+            <div className="canvas-stepper" aria-label="Generation pipeline">
+              <FlowDiagram stages={stages} variant="strip" />
+            </div>
+            <div className="canvas-toolbar">
+              <WizardControls />
+              <div className="canvas-toolbar-actions">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => dispatch({ type: "UNDO" })}
+                  disabled={!canUndo}
+                  className="gap-1.5 text-neutral-500 h-7 px-2.5 text-xs"
+                  title="Undo"
+                >
+                  <Undo2 className="h-3.5 w-3.5" />
+                  Undo
+                </Button>
+              </div>
             </div>
           </div>
 
-          {/* Scrollable form canvas */}
           <div className="canvas-wrapper">
             <Canvas />
           </div>

--- a/formsync/frontend/src/builder/Canvas.tsx
+++ b/formsync/frontend/src/builder/Canvas.tsx
@@ -189,8 +189,8 @@ const FieldRenderer: React.FC<FieldRendererProps> = ({ field, isSelected, onSele
 
     return (
         <div style={wrapStyle} onClick={(e) => { e.stopPropagation(); onSelect(); }}>
-            {/* Label row */}
-            {field.type !== 'checkbox' && (
+            {/* Label row — repeaters draw their own legend/title inside the plugin */}
+            {field.type !== 'checkbox' && field.type !== 'repeater' && (
                 <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.35rem' }}>
                     <label style={{ fontSize: '0.8rem', fontWeight: 600, color: overrides?.labelColor || 'var(--color-text)' }}>
                         {field.label}

--- a/formsync/frontend/src/builder/Canvas.tsx
+++ b/formsync/frontend/src/builder/Canvas.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Check, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useBuilder } from '../context/BuilderContext';
 import { FieldModel } from '../types';
 import { getPlugin } from './plugins/FieldPlugin';
@@ -268,17 +268,31 @@ const WizardStepHeader: React.FC<{
                         }} />
                     )}
                     <button
+                        type="button"
                         onClick={() => onStepClick(i)}
                         style={{
-                            width: 28, height: 28, borderRadius: '50%', border: 'none',
-                            cursor: 'pointer', fontWeight: 700, fontSize: '0.75rem', flexShrink: 0,
+                            width: 28,
+                            height: 28,
+                            borderRadius: '50%',
+                            border: 'none',
+                            cursor: 'pointer',
+                            fontWeight: 700,
+                            fontSize: '0.75rem',
+                            flexShrink: 0,
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
                             background: i === activeStep ? 'var(--color-primary)' : i < activeStep ? '#10b981' : '#e5e7eb',
                             color: i <= activeStep ? '#fff' : '#9ca3af',
                             transition: 'all 0.2s',
                         }}
                         title={step.title}
                     >
-                        {i < activeStep ? '✓' : i + 1}
+                        {i < activeStep ? (
+                            <Check size={14} strokeWidth={2.5} aria-hidden />
+                        ) : (
+                            i + 1
+                        )}
                     </button>
                 </React.Fragment>
             ))}

--- a/formsync/frontend/src/builder/Canvas.tsx
+++ b/formsync/frontend/src/builder/Canvas.tsx
@@ -3,7 +3,7 @@ import { Check, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useBuilder } from '../context/BuilderContext';
 import { FieldModel } from '../types';
 import { getPlugin } from './plugins/FieldPlugin';
-import { filterVisibleFields, evaluateCalcExpression } from '../lib/conditionEngine';
+import { filterVisibleFields, evaluateCalcExpression, pruneFieldsForWizardStep } from '../lib/conditionEngine';
 
 // ── Register all plugins ───────────────────────────────────────────────────────
 import './plugins/FileFieldPreview';
@@ -343,7 +343,7 @@ export const Canvas: React.FC = () => {
     const visibleFields = showPreview
         ? filterVisibleFields(orderedFields, previewValues, isWizardMode ? activeStep : undefined)
         : isWizardMode
-            ? orderedFields.filter((f) => f.stepIndex === undefined || f.stepIndex === activeStep)
+            ? pruneFieldsForWizardStep(orderedFields, activeStep)
             : orderedFields;
 
     const setPreviewValue = (key: string, value: unknown) =>

--- a/formsync/frontend/src/builder/Canvas.tsx
+++ b/formsync/frontend/src/builder/Canvas.tsx
@@ -336,8 +336,12 @@ export const Canvas: React.FC = () => {
         dispatch({ type: 'SET_PREVIEW_VALUE', payload: { key, value } });
 
     return (
-        <div className="canvas-area" onClick={() => dispatch({ type: 'SELECT_FIELD', payload: null })}>
-            <div className="form-preview" style={themeVars} onClick={(e) => e.stopPropagation()}>
+        <div
+            className="canvas-area"
+            style={themeVars}
+            onClick={() => dispatch({ type: 'SELECT_FIELD', payload: null })}
+        >
+            <div className="form-preview" onClick={(e) => e.stopPropagation()}>
 
                 {/* ── Mode banner ─────────────────────────────────────────────── */}
                 <div style={{

--- a/formsync/frontend/src/builder/LeftPanel.tsx
+++ b/formsync/frontend/src/builder/LeftPanel.tsx
@@ -54,8 +54,10 @@ const PaletteButton: React.FC<{
     onClick: () => void;
 }> = ({ label, Icon, onClick }) => (
     <button
+        type="button"
         onClick={onClick}
         title={`Add ${label}`}
+        aria-label={`Add ${label} field`}
         style={{
             display: 'flex',
             alignItems: 'center',
@@ -92,51 +94,63 @@ const PaletteButton: React.FC<{
 
 const FieldTreeItem: React.FC<{
     field: FieldModel;
-    isSelected: boolean;
-    onSelect: () => void;
-    onRemove: () => void;
+    selectedFieldId: string | null;
+    onSelect: (id: string) => void;
+    onRemove: (id: string) => void;
     indent?: number;
-}> = ({ field, isSelected, onSelect, onRemove, indent = 0 }) => (
-    <div>
-        <div
-            style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '0.35rem',
-                padding: '0.28rem 0.5rem',
-                paddingLeft: `${0.5 + indent * 1}rem`,
-                borderRadius: 4,
-                cursor: 'pointer',
-                fontSize: '0.72rem',
-                background: isSelected ? 'rgba(99,102,241,0.08)' : 'transparent',
-                border: `1px solid ${isSelected ? 'rgba(99,102,241,0.3)' : 'transparent'}`,
-                marginBottom: 1,
-            }}
-            onClick={onSelect}
-        >
-            <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: isSelected ? 600 : 400, color: isSelected ? '#6366f1' : '#334155' }}>
-                {field.label}
-            </span>
-            <span style={{ fontSize: '0.6rem', color: 'rgba(0,0,0,0.4)', flexShrink: 0, fontFamily: 'monospace' }}>{field.type}</span>
-            <button
-                onClick={(e) => { e.stopPropagation(); onRemove(); }}
-                title="Remove"
+}> = ({ field, selectedFieldId, onSelect, onRemove, indent = 0 }) => {
+    const isSelected = selectedFieldId === field.id;
+    return (
+        <div>
+            <div
                 style={{
-                    padding: '0 4px', lineHeight: '16px', fontSize: '0.85rem',
-                    border: 'none', background: 'transparent', color: 'rgba(0,0,0,0.4)',
-                    cursor: 'pointer', flexShrink: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.35rem',
+                    padding: '0.28rem 0.5rem',
+                    paddingLeft: `${0.5 + indent * 1}rem`,
+                    borderRadius: 4,
+                    cursor: 'pointer',
+                    fontSize: '0.72rem',
+                    background: isSelected ? 'rgba(99,102,241,0.08)' : 'transparent',
+                    border: `1px solid ${isSelected ? 'rgba(99,102,241,0.3)' : 'transparent'}`,
+                    marginBottom: 1,
                 }}
-                onMouseEnter={(e) => { e.currentTarget.style.color = '#ef4444'; }}
-                onMouseLeave={(e) => { e.currentTarget.style.color = 'rgba(0,0,0,0.4)'; }}
+                onClick={() => onSelect(field.id)}
             >
-                ×
-            </button>
+                <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: isSelected ? 600 : 400, color: isSelected ? '#6366f1' : '#334155' }}>
+                    {field.label}
+                </span>
+                <span style={{ fontSize: '0.6rem', color: 'rgba(0,0,0,0.4)', flexShrink: 0, fontFamily: 'monospace' }}>{field.type}</span>
+                <button
+                    type="button"
+                    onClick={(e) => { e.stopPropagation(); onRemove(field.id); }}
+                    title="Remove"
+                    aria-label={`Remove ${field.label}`}
+                    style={{
+                        padding: '0 4px', lineHeight: '16px', fontSize: '0.85rem',
+                        border: 'none', background: 'transparent', color: 'rgba(0,0,0,0.4)',
+                        cursor: 'pointer', flexShrink: 0,
+                    }}
+                    onMouseEnter={(e) => { e.currentTarget.style.color = '#ef4444'; }}
+                    onMouseLeave={(e) => { e.currentTarget.style.color = 'rgba(0,0,0,0.4)'; }}
+                >
+                    ×
+                </button>
+            </div>
+            {field.children?.map((child) => (
+                <FieldTreeItem
+                    key={child.id}
+                    field={child}
+                    selectedFieldId={selectedFieldId}
+                    onSelect={onSelect}
+                    onRemove={onRemove}
+                    indent={indent + 1}
+                />
+            ))}
         </div>
-        {field.children?.map((child) => (
-            <FieldTreeItem key={child.id} field={child} isSelected={false} onSelect={() => { }} onRemove={() => { }} indent={indent + 1} />
-        ))}
-    </div>
-);
+    );
+};
 
 // ─── Left Panel ───────────────────────────────────────────────────────────────
 
@@ -218,9 +232,9 @@ export const LeftPanel: React.FC = () => {
                                 <FieldTreeItem
                                     key={field.id}
                                     field={field}
-                                    isSelected={state.selectedFieldId === field.id}
-                                    onSelect={() => dispatch({ type: 'SELECT_FIELD', payload: field.id })}
-                                    onRemove={() => handleRemove(field.id)}
+                                    selectedFieldId={state.selectedFieldId}
+                                    onSelect={(id) => dispatch({ type: 'SELECT_FIELD', payload: id })}
+                                    onRemove={handleRemove}
                                 />
                             ))
                         )}

--- a/formsync/frontend/src/builder/LeftPanel.tsx
+++ b/formsync/frontend/src/builder/LeftPanel.tsx
@@ -1,7 +1,42 @@
 import React, { useState } from 'react';
+import {
+    DndContext,
+    KeyboardSensor,
+    PointerSensor,
+    closestCenter,
+    useSensor,
+    useSensors,
+    type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+    SortableContext,
+    arrayMove,
+    sortableKeyboardCoordinates,
+    useSortable,
+    verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { useBuilder, createField, collectAllFieldKeys } from '../context/BuilderContext';
 import { FieldModel, FieldType } from '../types';
-import { LucideIcon, Type, Mail, Lock, Hash, AlignLeft, Calendar, ChevronDown, CheckSquare, List, Upload, FileText, PenLine, Search, Calculator, Folder } from 'lucide-react';
+import {
+    LucideIcon,
+    Type,
+    Mail,
+    Lock,
+    Hash,
+    AlignLeft,
+    Calendar,
+    ChevronDown,
+    CheckSquare,
+    List,
+    Upload,
+    FileText,
+    PenLine,
+    Search,
+    Calculator,
+    Folder,
+    GripVertical,
+} from 'lucide-react';
 
 // ─── Palette Config ───────────────────────────────────────────────────────────
 
@@ -98,7 +133,9 @@ const FieldTreeItem: React.FC<{
     onSelect: (id: string) => void;
     onRemove: (id: string) => void;
     indent?: number;
-}> = ({ field, selectedFieldId, onSelect, onRemove, indent = 0 }) => {
+    /** Drag handle shown only on root row (indent 0) in Layers */
+    dragHandle?: React.ReactNode;
+}> = ({ field, selectedFieldId, onSelect, onRemove, indent = 0, dragHandle }) => {
     const isSelected = selectedFieldId === field.id;
     return (
         <div>
@@ -118,6 +155,7 @@ const FieldTreeItem: React.FC<{
                 }}
                 onClick={() => onSelect(field.id)}
             >
+                {indent === 0 && dragHandle ? dragHandle : null}
                 <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: isSelected ? 600 : 400, color: isSelected ? '#6366f1' : '#334155' }}>
                     {field.label}
                 </span>
@@ -152,11 +190,68 @@ const FieldTreeItem: React.FC<{
     );
 };
 
+const SortableRootFieldBlock: React.FC<{
+    field: FieldModel;
+    selectedFieldId: string | null;
+    onSelect: (id: string) => void;
+    onRemove: (id: string) => void;
+}> = ({ field, selectedFieldId, onSelect, onRemove }) => {
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+        id: field.id,
+    });
+    const style: React.CSSProperties = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.88 : 1,
+    };
+    const handle = (
+        <button
+            type="button"
+            {...attributes}
+            {...listeners}
+            onClick={(e) => e.stopPropagation()}
+            aria-label="Drag to reorder"
+            title="Drag to reorder"
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '2px',
+                border: 'none',
+                background: 'transparent',
+                color: '#94a3b8',
+                cursor: 'grab',
+                flexShrink: 0,
+                touchAction: 'none',
+            }}
+        >
+            <GripVertical size={14} strokeWidth={2} aria-hidden />
+        </button>
+    );
+    return (
+        <div ref={setNodeRef} style={style}>
+            <FieldTreeItem
+                field={field}
+                selectedFieldId={selectedFieldId}
+                onSelect={onSelect}
+                onRemove={onRemove}
+                indent={0}
+                dragHandle={handle}
+            />
+        </div>
+    );
+};
+
 // ─── Left Panel ───────────────────────────────────────────────────────────────
 
 export const LeftPanel: React.FC = () => {
     const { state, dispatch, isWizardMode } = useBuilder();
     const [tab, setTab] = useState<'palette' | 'tree'>('palette');
+
+    const sensors = useSensors(
+        useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+        useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    );
 
     const orderedFields = state.form.layout.order
         .map((id) => state.form.fields.find((f) => f.id === id))
@@ -175,6 +270,18 @@ export const LeftPanel: React.FC = () => {
 
     const handleRemove = (id: string) => {
         if (window.confirm('Remove this field?')) dispatch({ type: 'REMOVE_FIELD', payload: id });
+    };
+
+    const rootIds = displayFields.map((f) => f.id);
+
+    const handleLayersDragEnd = (event: DragEndEvent) => {
+        const { active, over } = event;
+        if (!over || active.id === over.id) return;
+        const oldIndex = rootIds.indexOf(active.id as string);
+        const newIndex = rootIds.indexOf(over.id as string);
+        if (oldIndex < 0 || newIndex < 0) return;
+        const nextOrder = arrayMove(rootIds, oldIndex, newIndex);
+        dispatch({ type: 'REORDER_FIELDS', payload: nextOrder });
     };
 
     const tabBtn = (active: boolean): React.CSSProperties => ({
@@ -228,15 +335,24 @@ export const LeftPanel: React.FC = () => {
                                 No fields yet.<br />Use the Palette tab.
                             </div>
                         ) : (
-                            displayFields.map((field) => (
-                                <FieldTreeItem
-                                    key={field.id}
-                                    field={field}
-                                    selectedFieldId={state.selectedFieldId}
-                                    onSelect={(id) => dispatch({ type: 'SELECT_FIELD', payload: id })}
-                                    onRemove={handleRemove}
-                                />
-                            ))
+                            <>
+                                <p style={{ fontSize: '0.62rem', color: 'rgba(0,0,0,0.45)', marginBottom: '0.5rem', lineHeight: 1.35 }}>
+                                    Drag the grip to reorder top-level fields. Canvas and export order match this list.
+                                </p>
+                                <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleLayersDragEnd}>
+                                    <SortableContext items={rootIds} strategy={verticalListSortingStrategy}>
+                                        {displayFields.map((field) => (
+                                            <SortableRootFieldBlock
+                                                key={field.id}
+                                                field={field}
+                                                selectedFieldId={state.selectedFieldId}
+                                                onSelect={(id) => dispatch({ type: 'SELECT_FIELD', payload: id })}
+                                                onRemove={handleRemove}
+                                            />
+                                        ))}
+                                    </SortableContext>
+                                </DndContext>
+                            </>
                         )}
                     </div>
                 )}

--- a/formsync/frontend/src/builder/LeftPanel.tsx
+++ b/formsync/frontend/src/builder/LeftPanel.tsx
@@ -16,7 +16,23 @@ import {
     verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { useBuilder, createField, collectAllFieldKeys, type CreateFieldOptions } from '../context/BuilderContext';
+import {
+    useBuilder,
+    createField,
+    collectAllFieldKeys,
+    findFieldInTree,
+    type CreateFieldOptions,
+} from '../context/BuilderContext';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '../components/ui/alert-dialog';
 import { FieldModel, FieldType } from '../types';
 import {
     LucideIcon,
@@ -249,6 +265,8 @@ const SortableRootFieldBlock: React.FC<{
 export const LeftPanel: React.FC = () => {
     const { state, dispatch, isWizardMode } = useBuilder();
     const [tab, setTab] = useState<'palette' | 'tree'>('palette');
+    const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
+    const [pendingRemoveId, setPendingRemoveId] = useState<string | null>(null);
 
     const sensors = useSensors(
         useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
@@ -270,9 +288,12 @@ export const LeftPanel: React.FC = () => {
         });
     };
 
-    const handleRemove = (id: string) => {
-        if (window.confirm('Remove this field?')) dispatch({ type: 'REMOVE_FIELD', payload: id });
+    const requestRemove = (id: string) => {
+        setPendingRemoveId(id);
+        setRemoveDialogOpen(true);
     };
+
+    const pendingField = pendingRemoveId ? findFieldInTree(state.form.fields, pendingRemoveId) : undefined;
 
     const rootIds = displayFields.map((f) => f.id);
 
@@ -356,7 +377,7 @@ export const LeftPanel: React.FC = () => {
                                                 field={field}
                                                 selectedFieldId={state.selectedFieldId}
                                                 onSelect={(id) => dispatch({ type: 'SELECT_FIELD', payload: id })}
-                                                onRemove={handleRemove}
+                                                onRemove={requestRemove}
                                             />
                                         ))}
                                     </SortableContext>
@@ -366,6 +387,38 @@ export const LeftPanel: React.FC = () => {
                     </div>
                 )}
             </div>
+
+            <AlertDialog
+                open={removeDialogOpen}
+                onOpenChange={(open) => {
+                    setRemoveDialogOpen(open);
+                    if (!open) setPendingRemoveId(null);
+                }}
+            >
+                <AlertDialogContent className="max-w-md rounded-xl border border-neutral-200 shadow-xl">
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Remove field?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            {pendingField
+                                ? `“${pendingField.label}” will be removed from the form. You can undo afterward from the toolbar.`
+                                : 'This field will be removed from the form. You can undo afterward from the toolbar.'}
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                            className="bg-red-600 text-white hover:bg-red-700 focus:ring-red-600"
+                            onClick={() => {
+                                if (pendingRemoveId) {
+                                    dispatch({ type: 'REMOVE_FIELD', payload: pendingRemoveId });
+                                }
+                            }}
+                        >
+                            Remove
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 };

--- a/formsync/frontend/src/builder/LeftPanel.tsx
+++ b/formsync/frontend/src/builder/LeftPanel.tsx
@@ -16,7 +16,7 @@ import {
     verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { useBuilder, createField, collectAllFieldKeys } from '../context/BuilderContext';
+import { useBuilder, createField, collectAllFieldKeys, type CreateFieldOptions } from '../context/BuilderContext';
 import { FieldModel, FieldType } from '../types';
 import {
     LucideIcon,
@@ -36,11 +36,12 @@ import {
     Calculator,
     Folder,
     GripVertical,
+    Table2,
 } from 'lucide-react';
 
 // ─── Palette Config ───────────────────────────────────────────────────────────
 
-type PaletteEntry = { type: FieldType; label: string; Icon: LucideIcon };
+type PaletteEntry = { type: FieldType; label: string; Icon: LucideIcon; repeaterAsTable?: boolean };
 type PaletteGroup = { title: string; fields: PaletteEntry[] };
 
 const PALETTE_GROUPS: PaletteGroup[] = [
@@ -67,6 +68,7 @@ const PALETTE_GROUPS: PaletteGroup[] = [
         fields: [
             { type: 'group', label: 'Group', Icon: Folder },
             { type: 'repeater', label: 'Repeater', Icon: List },
+            { type: 'repeater', label: 'Repeating table', Icon: Table2, repeaterAsTable: true },
         ],
     },
     {
@@ -259,12 +261,12 @@ export const LeftPanel: React.FC = () => {
     const unlistedFields = state.form.fields.filter((f) => !state.form.layout.order.includes(f.id));
     const displayFields = [...orderedFields, ...unlistedFields];
 
-    const handleAdd = (type: FieldType) => {
+    const handleAdd = (type: FieldType, palette?: CreateFieldOptions) => {
         const stepIndex = isWizardMode ? state.activeStep : undefined;
         const existingKeys = collectAllFieldKeys(state.form.fields);
         dispatch({
             type: 'ADD_FIELD',
-            payload: createField(type, stepIndex, existingKeys),
+            payload: createField(type, stepIndex, existingKeys, palette),
         });
     };
 
@@ -314,8 +316,15 @@ export const LeftPanel: React.FC = () => {
                                     {group.title}
                                 </div>
                                 <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.2rem' }}>
-                                    {group.fields.map(({ type, label, Icon }) => (
-                                        <PaletteButton key={type} label={label} Icon={Icon} onClick={() => handleAdd(type)} />
+                                    {group.fields.map(({ type, label, Icon, repeaterAsTable }) => (
+                                        <PaletteButton
+                                            key={`${type}-${label}`}
+                                            label={label}
+                                            Icon={Icon}
+                                            onClick={() =>
+                                                handleAdd(type, repeaterAsTable ? { repeaterAsTable: true } : undefined)
+                                            }
+                                        />
                                     ))}
                                 </div>
                             </div>

--- a/formsync/frontend/src/builder/RightPanel.tsx
+++ b/formsync/frontend/src/builder/RightPanel.tsx
@@ -1,7 +1,24 @@
 import React from 'react';
-import { useBuilder } from '../context/BuilderContext';
-import { findFieldInTree } from '../context/BuilderContext';
-import { FieldModel, ThemeConfig, ConditionRule, ConditionOperator, FieldConditions } from '../types';
+import { ChevronDown, ChevronUp, Trash2 } from 'lucide-react';
+import { useBuilder, findFieldInTree, createField, collectAllFieldKeys } from '../context/BuilderContext';
+import { FieldModel, FieldType, ThemeConfig, ConditionRule, ConditionOperator, FieldConditions } from '../types';
+
+/** Field types that can be added as repeater column / row content (nested repeaters omitted — unsupported in export). */
+const REPEATER_CHILD_TYPES: { type: FieldType; label: string }[] = [
+    { type: 'text', label: 'Text' },
+    { type: 'email', label: 'Email' },
+    { type: 'password', label: 'Password' },
+    { type: 'number', label: 'Number' },
+    { type: 'date', label: 'Date' },
+    { type: 'select', label: 'Dropdown' },
+    { type: 'textarea', label: 'Text area' },
+    { type: 'checkbox', label: 'Checkbox' },
+    { type: 'file', label: 'File' },
+    { type: 'richtext', label: 'Rich text' },
+    { type: 'signature', label: 'Signature' },
+    { type: 'typeahead', label: 'Typeahead' },
+    { type: 'calculated', label: 'Calculated' },
+];
 
 const THEME_PRESETS = {
     light: {
@@ -181,6 +198,39 @@ export const RightPanel: React.FC<RightPanelProps> = ({
         handleUiUpdate('x-ui', { ...currentXUI, ...patch });
     };
 
+    const addRepeaterColumnField = (type: FieldType) => {
+        if (!selectedField || selectedField.type !== 'repeater') return;
+        if (type === 'repeater') return;
+        const keys = collectAllFieldKeys(state.form.fields);
+        const stepIndex = isWizardMode ? state.activeStep : undefined;
+        const newChild = createField(type, stepIndex, keys);
+        const nextChildren = [...(selectedField.children ?? []), newChild];
+        dispatch({
+            type: 'UPDATE_FIELD',
+            payload: { fieldId: selectedField.id, updates: { children: nextChildren } },
+        });
+        dispatch({ type: 'SELECT_FIELD', payload: newChild.id });
+    };
+
+    const removeRepeaterColumn = (parentRepeaterId: string, childId: string) => {
+        dispatch({ type: 'REMOVE_FIELD', payload: childId });
+        dispatch({ type: 'SELECT_FIELD', payload: parentRepeaterId });
+    };
+
+    const moveRepeaterColumn = (parentRepeaterId: string, fromIndex: number, delta: -1 | 1) => {
+        const parent = findFieldInTree(state.form.fields, parentRepeaterId);
+        if (!parent || parent.type !== 'repeater') return;
+        const children = [...(parent.children ?? [])];
+        const toIndex = fromIndex + delta;
+        if (toIndex < 0 || toIndex >= children.length) return;
+        const [row] = children.splice(fromIndex, 1);
+        children.splice(toIndex, 0, row);
+        dispatch({
+            type: 'UPDATE_FIELD',
+            payload: { fieldId: parentRepeaterId, updates: { children } },
+        });
+    };
+
     const handleThemeUpdate = (updates: Partial<ThemeConfig>) =>
         dispatch({ type: 'UPDATE_THEME', payload: updates });
 
@@ -289,6 +339,139 @@ export const RightPanel: React.FC<RightPanelProps> = ({
 
                 {selectedField.type === 'repeater' && (
                     <>
+                        <Divider title="Repeater columns" />
+                        <p style={{ fontSize: '0.68rem', color: '#64748b', marginBottom: '0.5rem', lineHeight: 1.45 }}>
+                            Each field below is one table column (data table) or one block inside each repeated card (stacked cards). End users only add rows at runtime, not new columns.
+                        </p>
+                        {(selectedField.children ?? []).length === 0 ? (
+                            <p style={{ fontSize: '0.72rem', color: '#94a3b8', marginBottom: '0.45rem' }}>No columns yet — add a field type below.</p>
+                        ) : (
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', marginBottom: '0.55rem' }}>
+                                {(selectedField.children ?? []).map((c, idx, arr) => (
+                                    <div
+                                        key={c.id}
+                                        style={{
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            gap: '0.25rem',
+                                            padding: '0.25rem 0.35rem',
+                                            borderRadius: 5,
+                                            border: `1px solid ${state.selectedFieldId === c.id ? 'rgba(99,102,241,0.45)' : '#e2e8f0'}`,
+                                            background: state.selectedFieldId === c.id ? 'rgba(99,102,241,0.07)' : '#fff',
+                                        }}
+                                    >
+                                        <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+                                            <button
+                                                type="button"
+                                                title="Move up"
+                                                disabled={idx === 0}
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    moveRepeaterColumn(selectedField.id, idx, -1);
+                                                }}
+                                                style={{
+                                                    padding: 0,
+                                                    border: 'none',
+                                                    background: 'transparent',
+                                                    cursor: idx === 0 ? 'not-allowed' : 'pointer',
+                                                    color: idx === 0 ? '#cbd5e1' : '#64748b',
+                                                    lineHeight: 1,
+                                                }}
+                                            >
+                                                <ChevronUp size={14} strokeWidth={2} aria-hidden />
+                                            </button>
+                                            <button
+                                                type="button"
+                                                title="Move down"
+                                                disabled={idx === arr.length - 1}
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    moveRepeaterColumn(selectedField.id, idx, 1);
+                                                }}
+                                                style={{
+                                                    padding: 0,
+                                                    border: 'none',
+                                                    background: 'transparent',
+                                                    cursor: idx === arr.length - 1 ? 'not-allowed' : 'pointer',
+                                                    color: idx === arr.length - 1 ? '#cbd5e1' : '#64748b',
+                                                    lineHeight: 1,
+                                                }}
+                                            >
+                                                <ChevronDown size={14} strokeWidth={2} aria-hidden />
+                                            </button>
+                                        </div>
+                                        <button
+                                            type="button"
+                                            onClick={() => dispatch({ type: 'SELECT_FIELD', payload: c.id })}
+                                            style={{
+                                                flex: 1,
+                                                display: 'flex',
+                                                justifyContent: 'space-between',
+                                                alignItems: 'center',
+                                                padding: '0.25rem 0.35rem',
+                                                fontSize: '0.75rem',
+                                                border: 'none',
+                                                borderRadius: 4,
+                                                background: 'transparent',
+                                                cursor: 'pointer',
+                                                textAlign: 'left',
+                                                color: '#334155',
+                                                minWidth: 0,
+                                            }}
+                                        >
+                                            <span style={{ fontWeight: state.selectedFieldId === c.id ? 600 : 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{c.label}</span>
+                                            <span style={{ fontSize: '0.62rem', color: '#94a3b8', fontFamily: 'monospace', flexShrink: 0, marginLeft: 6 }}>{c.type}</span>
+                                        </button>
+                                        <button
+                                            type="button"
+                                            title="Remove column"
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                removeRepeaterColumn(selectedField.id, c.id);
+                                            }}
+                                            style={{
+                                                padding: '0.25rem',
+                                                border: 'none',
+                                                borderRadius: 4,
+                                                background: 'transparent',
+                                                cursor: 'pointer',
+                                                color: '#94a3b8',
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                justifyContent: 'center',
+                                            }}
+                                            aria-label={`Remove ${c.label}`}
+                                        >
+                                            <Trash2 size={15} strokeWidth={2} />
+                                        </button>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                        <div style={{ fontSize: '0.62rem', fontWeight: 600, color: '#94a3b8', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.35rem' }}>Add column</div>
+                        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '0.3rem' }}>
+                            {REPEATER_CHILD_TYPES.map(({ type, label }) => (
+                                <button
+                                    key={type}
+                                    type="button"
+                                    onClick={() => addRepeaterColumnField(type)}
+                                    className="control-input"
+                                    style={{
+                                        padding: '0.35rem 0.25rem',
+                                        fontSize: '0.68rem',
+                                        fontWeight: 500,
+                                        cursor: 'pointer',
+                                        border: '1px solid #e2e8f0',
+                                        borderRadius: 5,
+                                        background: '#f8fafc',
+                                        color: '#475569',
+                                    }}
+                                >
+                                    + {label}
+                                </button>
+                            ))}
+                        </div>
+
                         <Divider title="Repeater layout" />
                         <Group label="Row layout">
                             <select
@@ -300,7 +483,7 @@ export const RightPanel: React.FC<RightPanelProps> = ({
                                 <option value="table">Data table</option>
                             </select>
                             <p style={{ fontSize: '0.68rem', color: '#64748b', marginTop: '0.35rem', lineHeight: 1.4 }}>
-                                Use a data table for repeating rows such as qualifications. Generated React and static HTML match this layout. Submit payloads use JSON arrays (your API must accept them).
+                                Use stacked cards for tall rows or a data table for dense grids; exports match this choice. Submit payloads use JSON arrays (your API must accept them). Nested repeaters inside a repeater are not supported in React or static HTML export.
                             </p>
                         </Group>
                     </>

--- a/formsync/frontend/src/builder/RightPanel.tsx
+++ b/formsync/frontend/src/builder/RightPanel.tsx
@@ -277,6 +277,25 @@ export const RightPanel: React.FC<RightPanelProps> = ({
                     <textarea className="control-input" style={{ height: '56px', resize: 'vertical', paddingTop: '0.5rem' }} value={selectedField.ui?.helpText ?? ''} onChange={(e) => handleUiUpdate('helpText', e.target.value)} placeholder="Describe this field…" />
                 </Group>
 
+                {selectedField.type === 'repeater' && (
+                    <>
+                        <Divider title="Repeater layout" />
+                        <Group label="Row layout">
+                            <select
+                                className="control-input"
+                                value={(selectedField.ui as { displayMode?: string } | undefined)?.displayMode === 'table' ? 'table' : 'cards'}
+                                onChange={(e) => handleUiUpdate('displayMode', e.target.value)}
+                            >
+                                <option value="cards">Stacked cards</option>
+                                <option value="table">Data table</option>
+                            </select>
+                            <p style={{ fontSize: '0.68rem', color: '#64748b', marginTop: '0.35rem', lineHeight: 1.4 }}>
+                                Use a data table for repeating rows such as qualifications. Generated React and static HTML match this layout. Submit payloads use JSON arrays (your API must accept them).
+                            </p>
+                        </Group>
+                    </>
+                )}
+
                 {/* Dropdown options — visible for select fields */}
                 {(selectedField.type === 'select') && (
                     <>

--- a/formsync/frontend/src/builder/RightPanel.tsx
+++ b/formsync/frontend/src/builder/RightPanel.tsx
@@ -121,6 +121,26 @@ const ColorRow: React.FC<{ label: string; value: string; onChange: (v: string) =
     </div>
 );
 
+// ─── Generate Code footer (theme panel + field inspector) ───────────────────
+
+const GenerateCodeFooter: React.FC<{
+    onGenerate?: () => void;
+    isGenerating: boolean;
+}> = ({ onGenerate, isGenerating }) => (
+    <div className="panel-footer">
+        <button
+            type="button"
+            onClick={onGenerate}
+            disabled={isGenerating || !onGenerate}
+            className="btn-primary"
+            style={{ width: '100%', justifyContent: 'center', padding: '0.6rem 1rem' }}
+        >
+            <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z" /></svg>
+            {isGenerating ? 'Generating…' : 'Generate Code'}
+        </button>
+    </div>
+);
+
 // ─── Right Panel ──────────────────────────────────────────────────────────────
 
 interface RightPanelProps {
@@ -230,17 +250,7 @@ export const RightPanel: React.FC<RightPanelProps> = ({
                     </Group>
                 </div>
 
-                <div className="panel-footer">
-                    <button
-                        onClick={onGenerate}
-                        disabled={isGenerating || !onGenerate}
-                        className="btn-primary"
-                        style={{ width: '100%', justifyContent: 'center', padding: '0.6rem 1rem' }}
-                    >
-                        <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z" /></svg>
-                        {isGenerating ? 'Generating…' : 'Generate Code'}
-                    </button>
-                </div>
+                <GenerateCodeFooter onGenerate={onGenerate} isGenerating={isGenerating} />
             </div>
         );
     }
@@ -467,6 +477,8 @@ export const RightPanel: React.FC<RightPanelProps> = ({
                     <small style={{ color: '#94a3b8', fontSize: '0.7rem', fontFamily: 'monospace' }}>id: {selectedField.id}</small>
                 </div>
             </div>
+
+            <GenerateCodeFooter onGenerate={onGenerate} isGenerating={isGenerating} />
         </div>
     );
 };

--- a/formsync/frontend/src/builder/RightPanel.tsx
+++ b/formsync/frontend/src/builder/RightPanel.tsx
@@ -230,6 +230,10 @@ export const RightPanel: React.FC<RightPanelProps> = ({
         });
     };
 
+    const updateRepeaterChildColumnHeader = (childId: string, label: string) => {
+        dispatch({ type: 'UPDATE_FIELD', payload: { fieldId: childId, updates: { label } } });
+    };
+
     const handleThemeUpdate = (updates: Partial<ThemeConfig>) =>
         dispatch({ type: 'UPDATE_THEME', payload: updates });
 
@@ -340,7 +344,7 @@ export const RightPanel: React.FC<RightPanelProps> = ({
                     <>
                         <Divider title="Repeater columns" />
                         <p style={{ fontSize: '0.68rem', color: '#64748b', marginBottom: '0.5rem', lineHeight: 1.45 }}>
-                            Each field below is one table column (data table) or one block inside each repeated card (stacked cards). End users only add rows at runtime, not new columns.
+                            Each row below is one column. Edit the column header to set table headings and card labels. End users only add rows at runtime, not new columns.
                         </p>
                         {(selectedField.children ?? []).length === 0 ? (
                             <p style={{ fontSize: '0.72rem', color: '#94a3b8', marginBottom: '0.45rem' }}>No columns yet — add a field type below.</p>
@@ -399,28 +403,57 @@ export const RightPanel: React.FC<RightPanelProps> = ({
                                                 <ChevronDown size={14} strokeWidth={2} aria-hidden />
                                             </button>
                                         </div>
-                                        <button
-                                            type="button"
-                                            onClick={() => dispatch({ type: 'SELECT_FIELD', payload: c.id })}
+                                        <div
                                             style={{
                                                 flex: 1,
-                                                display: 'flex',
-                                                justifyContent: 'space-between',
-                                                alignItems: 'center',
-                                                padding: '0.25rem 0.35rem',
-                                                fontSize: '0.75rem',
-                                                border: 'none',
-                                                borderRadius: 4,
-                                                background: 'transparent',
-                                                cursor: 'pointer',
-                                                textAlign: 'left',
-                                                color: '#334155',
                                                 minWidth: 0,
+                                                display: 'flex',
+                                                flexDirection: 'column',
+                                                gap: '0.2rem',
                                             }}
                                         >
-                                            <span style={{ fontWeight: state.selectedFieldId === c.id ? 600 : 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{c.label}</span>
-                                            <span style={{ fontSize: '0.62rem', color: '#94a3b8', fontFamily: 'monospace', flexShrink: 0, marginLeft: 6 }}>{c.type}</span>
-                                        </button>
+                                            <label className="control-label" style={{ fontSize: '0.58rem', marginBottom: 0, color: '#94a3b8' }}>
+                                                Column header
+                                            </label>
+                                            <div style={{ display: 'flex', alignItems: 'center', gap: '0.35rem' }}>
+                                                <input
+                                                    type="text"
+                                                    className="control-input"
+                                                    value={c.label}
+                                                    onChange={(e) => updateRepeaterChildColumnHeader(c.id, e.target.value)}
+                                                    placeholder="Header label"
+                                                    aria-label={`Column header (${c.type})`}
+                                                    style={{
+                                                        flex: 1,
+                                                        minWidth: 0,
+                                                        fontSize: '0.78rem',
+                                                        padding: '0.35rem 0.45rem',
+                                                    }}
+                                                />
+                                                <button
+                                                    type="button"
+                                                    title="Open field settings (validation, placeholder…)"
+                                                    onClick={() => dispatch({ type: 'SELECT_FIELD', payload: c.id })}
+                                                    style={{
+                                                        flexShrink: 0,
+                                                        fontSize: '0.58rem',
+                                                        padding: '0.25rem 0.35rem',
+                                                        borderRadius: 4,
+                                                        border: '1px solid #e2e8f0',
+                                                        background:
+                                                            state.selectedFieldId === c.id ? 'rgba(99,102,241,0.1)' : '#f8fafc',
+                                                        color: '#64748b',
+                                                        fontFamily: 'monospace',
+                                                        cursor: 'pointer',
+                                                        maxWidth: '4.5rem',
+                                                        overflow: 'hidden',
+                                                        textOverflow: 'ellipsis',
+                                                    }}
+                                                >
+                                                    {c.type}
+                                                </button>
+                                            </div>
+                                        </div>
                                         <button
                                             type="button"
                                             title="Remove column"

--- a/formsync/frontend/src/builder/RightPanel.tsx
+++ b/formsync/frontend/src/builder/RightPanel.tsx
@@ -209,7 +209,6 @@ export const RightPanel: React.FC<RightPanelProps> = ({
             type: 'UPDATE_FIELD',
             payload: { fieldId: selectedField.id, updates: { children: nextChildren } },
         });
-        dispatch({ type: 'SELECT_FIELD', payload: newChild.id });
     };
 
     const removeRepeaterColumn = (parentRepeaterId: string, childId: string) => {
@@ -467,7 +466,7 @@ export const RightPanel: React.FC<RightPanelProps> = ({
                                         color: '#475569',
                                     }}
                                 >
-                                    + {label}
+                                    {label}
                                 </button>
                             ))}
                         </div>

--- a/formsync/frontend/src/builder/WizardControls.tsx
+++ b/formsync/frontend/src/builder/WizardControls.tsx
@@ -1,11 +1,70 @@
 import React, { useState } from 'react';
 import { Plus, Trash2, ChevronUp, ChevronDown, Layers } from 'lucide-react';
 import { useBuilder } from '../context/BuilderContext';
-import { FormStep } from '../types';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '../components/ui/alert-dialog';
+import { FormStep, FieldModel } from '../types';
+
+function assignStepIndexDeep(fields: FieldModel[], stepIdx: number): FieldModel[] {
+    return fields.map((f) => ({
+        ...f,
+        stepIndex: stepIdx,
+        children: f.children?.length ? assignStepIndexDeep(f.children, stepIdx) : f.children,
+    }));
+}
+
+function stripStepIndexDeep(fields: FieldModel[]): FieldModel[] {
+    return fields.map((f) => {
+        const { stepIndex: _, ...rest } = f;
+        const next = { ...rest } as FieldModel;
+        if (next.children?.length) {
+            return { ...next, children: stripStepIndexDeep(next.children) };
+        }
+        return next;
+    });
+}
+
+function remapStepIndicesAfterRemoval(fields: FieldModel[], removedIndex: number): FieldModel[] {
+    return fields.map((f) => {
+        let si = f.stepIndex;
+        if (si === removedIndex) si = 0;
+        else if (si !== undefined && si > removedIndex) si = si - 1;
+        const next = { ...f, stepIndex: si } as FieldModel;
+        if (f.children?.length) {
+            return { ...next, children: remapStepIndicesAfterRemoval(f.children, removedIndex) };
+        }
+        return next;
+    });
+}
+
+/** Leaf fields (inputs) assigned to the given step (effective step = stepIndex ?? 0). */
+function countLeavesOnStep(fields: FieldModel[], stepIdx: number): number {
+    let n = 0;
+    const walk = (fs: FieldModel[]) => {
+        for (const f of fs) {
+            if (f.type === 'group' || f.type === 'repeater') {
+                if (f.children?.length) walk(f.children);
+            } else if ((f.stepIndex ?? 0) === stepIdx) {
+                n += 1;
+            }
+        }
+    };
+    walk(fields);
+    return n;
+}
 
 export const WizardControls: React.FC = () => {
     const { state, dispatch, isWizardMode, stepCount } = useBuilder();
     const [expanded, setExpanded] = useState(false);
+    const [disableWizardOpen, setDisableWizardOpen] = useState(false);
 
     const steps = state.form.layout.steps ?? [];
 
@@ -20,7 +79,7 @@ export const WizardControls: React.FC = () => {
     };
 
     const handleEnable = () => {
-        const updatedFields = state.form.fields.map((f) => ({ ...f, stepIndex: 0 }));
+        const updatedFields = assignStepIndexDeep(state.form.fields, 0);
         dispatch({
             type: 'UPDATE_FORM',
             payload: {
@@ -35,17 +94,17 @@ export const WizardControls: React.FC = () => {
         setExpanded(true);
     };
 
-    const handleDisable = () => {
-        if (!window.confirm('Disabling wizard will remove step assignments from all fields.')) return;
+    const confirmDisableWizard = () => {
         dispatch({
             type: 'UPDATE_FORM',
             payload: {
                 ...state.form,
                 layout: { ...state.form.layout, steps: undefined },
-                fields: state.form.fields.map(({ stepIndex: _, ...rest }) => rest),
+                fields: stripStepIndexDeep(state.form.fields),
             },
         });
         setExpanded(false);
+        setDisableWizardOpen(false);
     };
 
     const addStep = () => {
@@ -57,11 +116,7 @@ export const WizardControls: React.FC = () => {
         if (steps.length <= 1) return;
         const removedIndex = steps.findIndex((s) => s.id === id);
         const newSteps = steps.filter((s) => s.id !== id);
-        const updatedFields = state.form.fields.map((f) => {
-            if (f.stepIndex === removedIndex) return { ...f, stepIndex: 0 };
-            if (f.stepIndex !== undefined && f.stepIndex > removedIndex) return { ...f, stepIndex: f.stepIndex - 1 };
-            return f;
-        });
+        const updatedFields = remapStepIndicesAfterRemoval(state.form.fields, removedIndex);
         dispatch({
             type: 'UPDATE_FORM',
             payload: {
@@ -94,77 +149,113 @@ export const WizardControls: React.FC = () => {
 
     // ─── Enabled state ──────────────────────────────────────────────────────────
     return (
-        <div className="wc-root">
-            {/* Summary row — always visible */}
-            <div className="wc-summary" onClick={() => setExpanded((v) => !v)}>
-                <div className="wc-summary-left">
-                    <Layers size={14} strokeWidth={1.75} className="wc-summary-icon" />
-                    <span className="wc-summary-title">Wizard</span>
-                    <span className="wc-badge">{stepCount} steps</span>
-                    <span className="wc-on-badge">ON</span>
+        <>
+            <div className="wc-root">
+                {/* Summary row — always visible */}
+                <div className="wc-summary" onClick={() => setExpanded((v) => !v)}>
+                    <div className="wc-summary-left">
+                        <Layers size={14} strokeWidth={1.75} className="wc-summary-icon" />
+                        <span className="wc-summary-title">Wizard</span>
+                        <span className="wc-badge">{stepCount} steps</span>
+                        <span className="wc-on-badge">ON</span>
+                    </div>
+                    <div className="wc-summary-right">
+                        <button
+                            type="button"
+                            className="wc-btn-add-inline"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                addStep();
+                            }}
+                            title="Add another wizard step"
+                        >
+                            <Plus size={12} strokeWidth={2.25} />
+                            Add step
+                        </button>
+                        <button
+                            type="button"
+                            className="wc-btn-disable"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                setDisableWizardOpen(true);
+                            }}
+                        >
+                            Disable
+                        </button>
+                        {expanded
+                            ? <ChevronUp size={13} className="wc-chevron" />
+                            : <ChevronDown size={13} className="wc-chevron" />}
+                    </div>
                 </div>
-                <div className="wc-summary-right">
-                    <button
-                        className="wc-btn-disable"
-                        onClick={(e) => { e.stopPropagation(); handleDisable(); }}
-                    >
-                        Disable
-                    </button>
-                    {expanded
-                        ? <ChevronUp size={13} className="wc-chevron" />
-                        : <ChevronDown size={13} className="wc-chevron" />}
-                </div>
+
+                {/* Step list — visible when expanded */}
+                {expanded && (
+                    <div className="wc-steps">
+                        {steps.map((step, i) => {
+                            const fieldCount = countLeavesOnStep(state.form.fields, i);
+                            const isActive = state.activeStep === i;
+                            return (
+                                <div
+                                    key={step.id}
+                                    className={`wc-step-row ${isActive ? 'wc-step-row--active' : ''}`}
+                                    onClick={() => dispatch({ type: 'SET_STEP', payload: i })}
+                                >
+                                    <div className={`wc-step-num ${isActive ? 'wc-step-num--active' : ''}`}>
+                                        {i + 1}
+                                    </div>
+
+                                    <input
+                                        className="wc-step-input"
+                                        value={step.title}
+                                        onChange={(e) => { e.stopPropagation(); renameStep(step.id, e.target.value); }}
+                                        onClick={(e) => e.stopPropagation()}
+                                    />
+
+                                    <span className="wc-step-count">
+                                        {fieldCount} {fieldCount !== 1 ? 'fields' : 'field'}
+                                    </span>
+
+                                    {steps.length > 1 && (
+                                        <button
+                                            type="button"
+                                            className="wc-step-remove"
+                                            onClick={(e) => { e.stopPropagation(); removeStep(step.id); }}
+                                        >
+                                            <Trash2 size={11} strokeWidth={2} />
+                                        </button>
+                                    )}
+                                </div>
+                            );
+                        })}
+
+                        <button type="button" className="wc-add-step" onClick={addStep}>
+                            <Plus size={12} />
+                            Add step
+                        </button>
+                    </div>
+                )}
             </div>
 
-            {/* Step list — visible when expanded */}
-            {expanded && (
-                <div className="wc-steps">
-                    {steps.map((step, i) => {
-                        const fieldCount = state.form.fields.filter((f) => f.stepIndex === i).length;
-                        const isActive = state.activeStep === i;
-                        return (
-                            <div
-                                key={step.id}
-                                className={`wc-step-row ${isActive ? 'wc-step-row--active' : ''}`}
-                                onClick={() => dispatch({ type: 'SET_STEP', payload: i })}
-                            >
-                                {/* Step number badge — circle */}
-                                <div className={`wc-step-num ${isActive ? 'wc-step-num--active' : ''}`}>
-                                    {i + 1}
-                                </div>
-
-                                {/* Editable step title */}
-                                <input
-                                    className="wc-step-input"
-                                    value={step.title}
-                                    onChange={(e) => { e.stopPropagation(); renameStep(step.id, e.target.value); }}
-                                    onClick={(e) => e.stopPropagation()}
-                                />
-
-                                {/* Field count */}
-                                <span className="wc-step-count">
-                                    {fieldCount} {fieldCount !== 1 ? 'fields' : 'field'}
-                                </span>
-
-                                {/* Remove button */}
-                                {steps.length > 1 && (
-                                    <button
-                                        className="wc-step-remove"
-                                        onClick={(e) => { e.stopPropagation(); removeStep(step.id); }}
-                                    >
-                                        <Trash2 size={11} strokeWidth={2} />
-                                    </button>
-                                )}
-                            </div>
-                        );
-                    })}
-
-                    <button className="wc-add-step" onClick={addStep}>
-                        <Plus size={12} />
-                        Add step
-                    </button>
-                </div>
-            )}
-        </div>
+            <AlertDialog open={disableWizardOpen} onOpenChange={setDisableWizardOpen}>
+                <AlertDialogContent className="max-w-md rounded-xl border border-neutral-200 shadow-xl">
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Disable wizard?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Step assignments will be removed from all fields, including fields inside groups and repeaters.
+                            You can undo afterward from the toolbar.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                            className="bg-red-600 text-white hover:bg-red-700 focus:ring-red-600"
+                            onClick={confirmDisableWizard}
+                        >
+                            Disable wizard
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </>
     );
 };

--- a/formsync/frontend/src/builder/builder.css
+++ b/formsync/frontend/src/builder/builder.css
@@ -60,10 +60,11 @@
 
 .builder-body {
   display: grid;
-  grid-template-columns: 232px 1fr 256px;
+  grid-template-columns: 232px minmax(0, 1fr) 256px;
   flex: 1;
   min-height: 0;
   overflow: hidden;
+  width: 100%;
 }
 
 /* ── Sidebars ─────────────────────────────────────────────── */
@@ -94,41 +95,45 @@
   background: var(--canvas-bg);
 }
 
-/* Canvas stepper — stays below navbar; keep above wizard overflow in paint order */
-.canvas-stepper {
+/* Pipeline + wizard: one header band under the global navbar */
+.builder-canvas-header {
   flex-shrink: 0;
-  padding: 0.6rem 1rem;
+  display: flex;
+  flex-direction: column;
   background: var(--toolbar-bg);
   border-bottom: 1px solid var(--toolbar-border);
+}
+
+/* Canvas stepper — horizontal scroll on small screens */
+.canvas-stepper {
+  flex-shrink: 0;
+  padding: 0.35rem 1rem 0.45rem;
+  background: transparent;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.95);
   overflow-x: auto;
   scrollbar-width: none;
-  position: relative;
-  z-index: 2;
 }
 
 .canvas-stepper::-webkit-scrollbar {
   display: none;
 }
 
-/* Canvas toolbar — grows with wizard panel (fixed height caused overflow to paint over the stepper) */
+/* Wizard + Undo — sits below pipeline in the same chrome strip */
 .canvas-toolbar {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   flex-shrink: 0;
   min-height: 40px;
-  padding: 0.35rem 0.5rem 0.35rem 0;
+  padding: 0.3rem 1rem 0.4rem 0.5rem;
   gap: 0.5rem;
-  background: var(--toolbar-bg);
-  border-bottom: 1px solid var(--toolbar-border);
-  position: relative;
-  z-index: 1;
+  background: transparent;
 }
 
 .canvas-toolbar-actions {
   flex-shrink: 0;
   align-self: center;
-  padding-right: 0.35rem;
+  padding-right: 0.25rem;
 }
 
 .canvas-wrapper {

--- a/formsync/frontend/src/builder/builder.css
+++ b/formsync/frontend/src/builder/builder.css
@@ -94,7 +94,7 @@
   background: var(--canvas-bg);
 }
 
-/* Canvas stepper */
+/* Canvas stepper — stays below navbar; keep above wizard overflow in paint order */
 .canvas-stepper {
   flex-shrink: 0;
   padding: 0.6rem 1rem;
@@ -102,27 +102,33 @@
   border-bottom: 1px solid var(--toolbar-border);
   overflow-x: auto;
   scrollbar-width: none;
+  position: relative;
+  z-index: 2;
 }
 
 .canvas-stepper::-webkit-scrollbar {
   display: none;
 }
 
-/* Canvas toolbar */
+/* Canvas toolbar — grows with wizard panel (fixed height caused overflow to paint over the stepper) */
 .canvas-toolbar {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   flex-shrink: 0;
-  height: 40px;
-  padding: 0 0.5rem 0 0;
+  min-height: 40px;
+  padding: 0.35rem 0.5rem 0.35rem 0;
+  gap: 0.5rem;
   background: var(--toolbar-bg);
   border-bottom: 1px solid var(--toolbar-border);
+  position: relative;
+  z-index: 1;
 }
 
 .canvas-toolbar-actions {
   flex-shrink: 0;
-  padding-right: 0.5rem;
+  align-self: center;
+  padding-right: 0.35rem;
 }
 
 .canvas-wrapper {
@@ -241,10 +247,9 @@
   flex: 1;
   min-width: 0;
   border-right: 1px solid var(--toolbar-border);
-  height: 100%;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  align-self: stretch;
 }
 
 .wc-summary {
@@ -252,7 +257,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 0 0.875rem;
-  height: 40px;
+  min-height: 36px;
   cursor: pointer;
   background: transparent;
   transition: background 0.1s;
@@ -271,7 +276,32 @@
 .wc-summary-right {
   display: flex;
   align-items: center;
-  gap: 0.45rem;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+/* Always-visible add step (also duplicated in expanded list) */
+.wc-btn-add-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-shrink: 0;
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 5px;
+  border: 1px dashed rgba(99, 102, 241, 0.45);
+  background: rgba(99, 102, 241, 0.06);
+  color: var(--accent);
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.12s, border-color 0.12s;
+}
+
+.wc-btn-add-inline:hover {
+  background: var(--accent-subtle);
+  border-color: var(--accent);
 }
 
 .wc-summary-icon {

--- a/formsync/frontend/src/builder/plugins/CalculatedFieldPreview.tsx
+++ b/formsync/frontend/src/builder/plugins/CalculatedFieldPreview.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { FieldPluginProps, registerPlugin } from './FieldPlugin';
+import { resolveFieldStyleOverrides } from './fieldPreviewStyles';
 
-const CalculatedFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
+const CalculatedFieldPreview: React.FC<FieldPluginProps> = ({ field, theme }) => {
     const formula = field['x-calc'] ?? '';
+    const { border, surface, label, hint } = resolveFieldStyleOverrides(field, theme);
 
     return (
         <div style={{ pointerEvents: 'none' }}>
@@ -10,21 +12,20 @@ const CalculatedFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                 style={{
                     display: 'flex',
                     alignItems: 'center',
-                    border: '1px solid #d1d5db',
+                    border: `1px solid ${border}`,
                     borderRadius: 6,
-                    background: '#f9fafb',
+                    background: `color-mix(in srgb, ${hint} 6%, ${surface})`,
                     padding: '0 0.75rem',
                     height: '38px',
                     gap: '0.5rem',
                     cursor: 'not-allowed',
                 }}
             >
-                {/* = symbol badge */}
                 <span
                     style={{
                         fontSize: '0.85rem',
                         fontWeight: 700,
-                        color: '#6b7280',
+                        color: hint,
                         fontFamily: 'monospace',
                     }}
                 >
@@ -34,7 +35,7 @@ const CalculatedFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                     style={{
                         flex: 1,
                         fontSize: '0.875rem',
-                        color: formula ? '#1f2937' : '#9ca3af',
+                        color: formula ? label : hint,
                         fontFamily: 'monospace',
                         fontStyle: formula ? 'normal' : 'italic',
                         overflow: 'hidden',
@@ -44,13 +45,12 @@ const CalculatedFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                 >
                     {formula || 'No formula defined — edit in properties'}
                 </span>
-                {/* Read-only badge */}
                 <span
                     style={{
                         fontSize: '0.68rem',
                         padding: '2px 6px',
-                        background: '#e5e7eb',
-                        color: '#6b7280',
+                        background: `color-mix(in srgb, ${border} 40%, ${surface})`,
+                        color: hint,
                         borderRadius: 10,
                         fontWeight: 600,
                         whiteSpace: 'nowrap',
@@ -60,8 +60,18 @@ const CalculatedFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                 </span>
             </div>
             {formula && (
-                <div style={{ marginTop: '0.25rem', fontSize: '0.72rem', color: '#6b7280' }}>
-                    Formula: <code style={{ background: '#f3f4f6', padding: '1px 4px', borderRadius: 3 }}>{formula}</code>
+                <div style={{ marginTop: '0.25rem', fontSize: '0.72rem', color: hint }}>
+                    Formula:{' '}
+                    <code
+                        style={{
+                            background: `color-mix(in srgb, ${hint} 10%, ${surface})`,
+                            padding: '1px 4px',
+                            borderRadius: 3,
+                            color: label,
+                        }}
+                    >
+                        {formula}
+                    </code>
                 </div>
             )}
         </div>

--- a/formsync/frontend/src/builder/plugins/FileFieldPreview.tsx
+++ b/formsync/frontend/src/builder/plugins/FileFieldPreview.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FolderUp } from 'lucide-react';
 import { FieldPluginProps, registerPlugin } from './FieldPlugin';
 
 const FileFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
@@ -21,7 +22,9 @@ const FileFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                 pointerEvents: 'none',
             }}
         >
-            <div style={{ fontSize: '2rem', marginBottom: '0.5rem' }}>📁</div>
+            <div style={{ marginBottom: '0.5rem', display: 'flex', justifyContent: 'center', color: '#2563eb' }}>
+                <FolderUp size={28} strokeWidth={1.75} aria-hidden />
+            </div>
             <div style={{ fontWeight: 600, marginBottom: '0.25rem' }}>
                 {multiple ? 'Drop files here or click to browse' : 'Drop a file here or click to browse'}
             </div>

--- a/formsync/frontend/src/builder/plugins/FileFieldPreview.tsx
+++ b/formsync/frontend/src/builder/plugins/FileFieldPreview.tsx
@@ -1,34 +1,36 @@
 import React from 'react';
 import { FolderUp } from 'lucide-react';
 import { FieldPluginProps, registerPlugin } from './FieldPlugin';
+import { resolveFieldStyleOverrides } from './fieldPreviewStyles';
 
-const FileFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
+const FileFieldPreview: React.FC<FieldPluginProps> = ({ field, theme }) => {
     const xui = field.ui?.['x-ui'];
     const accept = xui?.accept ?? '*/*';
     const multiple = xui?.multiple ?? false;
     const maxMB = xui?.maxFileSizeBytes ? (xui.maxFileSizeBytes / (1024 * 1024)).toFixed(1) : null;
+    const { border, surface, label, hint, accent } = resolveFieldStyleOverrides(field, theme);
 
     return (
         <div
             style={{
-                border: '2px dashed #93c5fd',
+                border: `2px dashed ${border}`,
                 borderRadius: 8,
                 padding: '1.5rem',
                 textAlign: 'center',
-                background: '#eff6ff',
-                color: '#1d4ed8',
+                background: `color-mix(in srgb, ${accent} 8%, ${surface})`,
+                color: label,
                 fontSize: '0.875rem',
                 cursor: 'pointer',
                 pointerEvents: 'none',
             }}
         >
-            <div style={{ marginBottom: '0.5rem', display: 'flex', justifyContent: 'center', color: '#2563eb' }}>
+            <div style={{ marginBottom: '0.5rem', display: 'flex', justifyContent: 'center', color: accent }}>
                 <FolderUp size={28} strokeWidth={1.75} aria-hidden />
             </div>
-            <div style={{ fontWeight: 600, marginBottom: '0.25rem' }}>
+            <div style={{ fontWeight: 600, marginBottom: '0.25rem', color: label }}>
                 {multiple ? 'Drop files here or click to browse' : 'Drop a file here or click to browse'}
             </div>
-            <div style={{ color: '#3b82f6', fontSize: '0.75rem' }}>
+            <div style={{ color: hint, fontSize: '0.75rem' }}>
                 Accepts: {accept}
                 {maxMB && ` · Max ${maxMB} MB`}
             </div>

--- a/formsync/frontend/src/builder/plugins/RepeaterFieldPreview.tsx
+++ b/formsync/frontend/src/builder/plugins/RepeaterFieldPreview.tsx
@@ -37,6 +37,85 @@ const InnerFieldRow: React.FC<{ label: string; type: string }> = ({ label, type 
 
 const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
     const children = field.children ?? [];
+    const isTable = (field.ui as { displayMode?: string } | undefined)?.displayMode === 'table';
+
+    if (isTable && children.length > 0) {
+        return (
+            <div
+                style={{
+                    border: '1px solid #c7d2fe',
+                    borderRadius: 8,
+                    overflow: 'hidden',
+                    background: '#f5f3ff',
+                    pointerEvents: 'none',
+                }}
+            >
+                <div
+                    style={{
+                        background: '#ede9fe',
+                        padding: '0.5rem 0.75rem',
+                        fontWeight: 600,
+                        fontSize: '0.85rem',
+                        color: '#5b21b6',
+                        borderBottom: '1px solid #c4b5fd',
+                    }}
+                >
+                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35rem' }}>
+                        <ClipboardList size={15} strokeWidth={2} aria-hidden />
+                        <span>{field.label} (table)</span>
+                    </span>
+                </div>
+                <div style={{ overflowX: 'auto', padding: '0.5rem' }}>
+                    <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.72rem' }}>
+                        <thead>
+                            <tr style={{ background: '#faf5ff' }}>
+                                {children.map((c) => (
+                                    <th
+                                        key={c.id}
+                                        style={{
+                                            border: '1px solid #ddd6fe',
+                                            padding: '0.35rem 0.5rem',
+                                            textAlign: 'left',
+                                            fontWeight: 600,
+                                            color: '#4c1d95',
+                                        }}
+                                    >
+                                        {c.label}
+                                    </th>
+                                ))}
+                                <th style={{ border: '1px solid #ddd6fe', padding: '0.35rem', width: '4rem' }} />
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                {children.map((c) => (
+                                    <td key={c.id} style={{ border: '1px solid #e9d5ff', padding: '0.35rem', color: '#9ca3af', fontStyle: 'italic' }}>
+                                        {c.type}
+                                    </td>
+                                ))}
+                                <td style={{ border: '1px solid #e9d5ff', padding: '0.35rem', textAlign: 'right', fontSize: '0.65rem', color: '#7c3aed' }}>
+                                    Remove
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div
+                    style={{
+                        padding: '0.5rem 0.75rem',
+                        borderTop: '1px dashed #c4b5fd',
+                        display: 'flex',
+                        justifyContent: 'center',
+                        fontSize: '0.8rem',
+                        color: '#7c3aed',
+                        fontWeight: 500,
+                    }}
+                >
+                    + Add row
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div

--- a/formsync/frontend/src/builder/plugins/RepeaterFieldPreview.tsx
+++ b/formsync/frontend/src/builder/plugins/RepeaterFieldPreview.tsx
@@ -1,15 +1,36 @@
 import React from 'react';
 import { ClipboardList } from 'lucide-react';
+import { FieldModel } from '../../types';
 import { FieldPluginProps, registerPlugin } from './FieldPlugin';
 
+type Ov = Record<string, string>;
+
+function resolveRepeaterChrome(field: FieldModel, theme: Record<string, string | number>) {
+    const o = field.ui?.styleOverrides as Ov | undefined;
+    const t = theme as Record<string, string>;
+    const border = o?.borderColor ?? t['--color-border'] ?? '#e2e8f0';
+    const surface = o?.backgroundColor ?? t['--color-surface'] ?? '#f8fafc';
+    const label = o?.labelColor ?? t['--color-text'] ?? '#0f172a';
+    const hint = o?.inputTextColor ?? t['--color-muted'] ?? '#64748b';
+    const accent = o?.focusColor ?? t['--color-primary'] ?? '#6366f1';
+    return { border, surface, label, hint, accent, o };
+}
+
 // A small inner field preview row used inside the repeater section
-const InnerFieldRow: React.FC<{ label: string; type: string }> = ({ label, type }) => (
+const InnerFieldRow: React.FC<{ label: string; type: string; labelColor: string; borderColor: string; inputBg: string; hintColor: string }> = ({
+    label,
+    type,
+    labelColor,
+    borderColor,
+    inputBg,
+    hintColor,
+}) => (
     <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.5rem' }}>
         <label
             style={{
                 minWidth: '80px',
                 fontSize: '0.78rem',
-                color: '#374151',
+                color: labelColor,
                 fontWeight: 500,
             }}
         >
@@ -19,14 +40,14 @@ const InnerFieldRow: React.FC<{ label: string; type: string }> = ({ label, type 
             style={{
                 flex: 1,
                 height: '30px',
-                border: '1px solid #d1d5db',
+                border: `1px solid ${borderColor}`,
                 borderRadius: 4,
-                background: '#fff',
+                background: inputBg,
                 padding: '0 0.5rem',
                 display: 'flex',
                 alignItems: 'center',
                 fontSize: '0.78rem',
-                color: '#9ca3af',
+                color: hintColor,
                 fontStyle: 'italic',
             }}
         >
@@ -35,48 +56,54 @@ const InnerFieldRow: React.FC<{ label: string; type: string }> = ({ label, type 
     </div>
 );
 
-const theadCellStyle: React.CSSProperties = {
-    border: '1px solid #c4b5fd',
-    padding: '0.45rem 0.65rem',
-    textAlign: 'left',
-    fontWeight: 700,
-    fontSize: '0.78rem',
-    letterSpacing: '0.02em',
-    color: '#1e1b4b',
-    background: '#e9e5ff',
-};
-
-const bodyCellStyle: React.CSSProperties = {
-    border: '1px solid #ddd6fe',
-    padding: '0.4rem 0.5rem',
-    color: '#64748b',
-    fontSize: '0.75rem',
-};
-
-const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
+const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field, theme }) => {
     const children = field.children ?? [];
     const isTable = (field.ui as { displayMode?: string } | undefined)?.displayMode === 'table';
+    const { border, surface, label, hint, accent } = resolveRepeaterChrome(field, theme);
+    const inputBg =
+        (field.ui?.styleOverrides as Ov | undefined)?.backgroundColor ??
+        (theme['--color-input-bg'] as string) ??
+        '#ffffff';
+    const errColor = (theme['--color-error'] as string) ?? '#dc2626';
+
+    const theadCellStyle: React.CSSProperties = {
+        border: `1px solid ${border}`,
+        padding: '0.45rem 0.65rem',
+        textAlign: 'left',
+        fontWeight: 700,
+        fontSize: '0.78rem',
+        letterSpacing: '0.02em',
+        color: label,
+        background: `color-mix(in srgb, ${label} 12%, ${surface})`,
+    };
+
+    const bodyCellStyle: React.CSSProperties = {
+        border: `1px solid ${border}`,
+        padding: '0.4rem 0.5rem',
+        color: hint,
+        fontSize: '0.75rem',
+    };
 
     if (isTable) {
         const colCount = Math.max(children.length, 1);
         return (
             <div
                 style={{
-                    border: '1px solid #c7d2fe',
+                    border: `1px solid ${border}`,
                     borderRadius: 8,
                     overflow: 'hidden',
-                    background: '#fafaff',
+                    background: surface,
                     pointerEvents: 'none',
                 }}
             >
                 <div
                     style={{
-                        background: '#ede9fe',
+                        background: `color-mix(in srgb, ${accent} 14%, ${surface})`,
                         padding: '0.5rem 0.75rem',
                         fontWeight: 600,
                         fontSize: '0.85rem',
-                        color: '#5b21b6',
-                        borderBottom: '1px solid #c4b5fd',
+                        color: label,
+                        borderBottom: `1px solid ${border}`,
                     }}
                 >
                     <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35rem' }}>
@@ -91,8 +118,8 @@ const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                             width: '100%',
                             borderCollapse: 'collapse',
                             fontSize: '0.8125rem',
-                            background: '#fff',
-                            border: '1px solid #ddd6fe',
+                            background: inputBg,
+                            border: `1px solid ${border}`,
                             borderRadius: 6,
                             overflow: 'hidden',
                         }}
@@ -104,7 +131,7 @@ const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                                         <th key={c.id} scope="col" style={theadCellStyle}>
                                             {c.label}
                                             {c.required ? (
-                                                <span style={{ color: '#b91c1c', marginLeft: 2 }} aria-hidden="true">
+                                                <span style={{ color: errColor, marginLeft: 2 }} aria-hidden="true">
                                                     *
                                                 </span>
                                             ) : null}
@@ -122,7 +149,7 @@ const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                                         ...theadCellStyle,
                                         width: '5.5rem',
                                         textAlign: 'right',
-                                        background: '#f5f3ff',
+                                        background: `color-mix(in srgb, ${accent} 10%, ${surface})`,
                                     }}
                                 >
                                     Actions
@@ -142,7 +169,7 @@ const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                                             ...bodyCellStyle,
                                             textAlign: 'right',
                                             fontSize: '0.7rem',
-                                            color: '#7c3aed',
+                                            color: accent,
                                             fontWeight: 600,
                                             fontStyle: 'normal',
                                         }}
@@ -158,8 +185,8 @@ const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                                             ...bodyCellStyle,
                                             textAlign: 'center',
                                             padding: '0.85rem',
-                                            background: '#faf5ff',
-                                            color: '#5b21b6',
+                                            background: `color-mix(in srgb, ${accent} 8%, ${surface})`,
+                                            color: label,
                                             fontStyle: 'normal',
                                         }}
                                     >
@@ -174,11 +201,11 @@ const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                 <div
                     style={{
                         padding: '0.5rem 0.75rem',
-                        borderTop: '1px dashed #c4b5fd',
+                        borderTop: `1px dashed ${border}`,
                         display: 'flex',
                         justifyContent: 'center',
                         fontSize: '0.8rem',
-                        color: '#7c3aed',
+                        color: accent,
                         fontWeight: 500,
                     }}
                 >
@@ -191,22 +218,22 @@ const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
     return (
         <div
             style={{
-                border: '1px solid #c7d2fe',
+                border: `1px solid ${border}`,
                 borderRadius: 8,
                 overflow: 'hidden',
-                background: '#f5f3ff',
+                background: surface,
                 pointerEvents: 'none',
             }}
         >
             {/* Section header */}
             <div
                 style={{
-                    background: '#ede9fe',
+                    background: `color-mix(in srgb, ${accent} 14%, ${surface})`,
                     padding: '0.5rem 0.75rem',
                     fontWeight: 600,
                     fontSize: '0.85rem',
-                    color: '#5b21b6',
-                    borderBottom: '1px solid #c4b5fd',
+                    color: label,
+                    borderBottom: `1px solid ${border}`,
                 }}
             >
                 <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35rem' }}>
@@ -221,13 +248,21 @@ const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
             <div style={{ padding: '0.75rem' }}>
                 {children.length > 0 ? (
                     children.map((child) => (
-                        <InnerFieldRow key={child.id} label={child.label} type={child.type} />
+                        <InnerFieldRow
+                            key={child.id}
+                            label={child.label}
+                            type={child.type}
+                            labelColor={label}
+                            borderColor={border}
+                            inputBg={inputBg}
+                            hintColor={hint}
+                        />
                     ))
                 ) : (
                     <div
                         style={{
                             textAlign: 'center',
-                            color: '#8b5cf6',
+                            color: accent,
                             fontSize: '0.8rem',
                             padding: '0.5rem',
                         }}
@@ -241,7 +276,7 @@ const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
             <div
                 style={{
                     padding: '0.5rem 0.75rem',
-                    borderTop: '1px dashed #c4b5fd',
+                    borderTop: `1px dashed ${border}`,
                     display: 'flex',
                     justifyContent: 'center',
                 }}
@@ -249,7 +284,7 @@ const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                 <span
                     style={{
                         fontSize: '0.8rem',
-                        color: '#7c3aed',
+                        color: accent,
                         cursor: 'default',
                         fontWeight: 500,
                     }}

--- a/formsync/frontend/src/builder/plugins/RepeaterFieldPreview.tsx
+++ b/formsync/frontend/src/builder/plugins/RepeaterFieldPreview.tsx
@@ -139,8 +139,7 @@ const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field, theme }) => {
                                     ))
                                 ) : (
                                     <th scope="col" style={theadCellStyle}>
-                                        {/* Placeholder until user adds Year, Experience, etc. as child fields */}
-                                        Columns — add child fields (e.g. Year, Experience)
+                                        Columns — use the right sidebar → Repeater columns
                                     </th>
                                 )}
                                 <th
@@ -190,8 +189,9 @@ const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field, theme }) => {
                                             fontStyle: 'normal',
                                         }}
                                     >
-                                        Select this repeater → <strong>Properties</strong> → add each column as a
-                                        child field. Labels become the table headings.
+                                        Select this repeater, then use the <strong>right sidebar</strong> →{' '}
+                                        <strong>Repeater columns</strong> to add fields. Labels become the table
+                                        headings.
                                     </td>
                                 </tr>
                             )}
@@ -267,7 +267,7 @@ const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field, theme }) => {
                             padding: '0.5rem',
                         }}
                     >
-                        No child fields yet — add fields in the properties panel
+                        No child fields yet — use the right sidebar → Repeater columns to add fields
                     </div>
                 )}
             </div>

--- a/formsync/frontend/src/builder/plugins/RepeaterFieldPreview.tsx
+++ b/formsync/frontend/src/builder/plugins/RepeaterFieldPreview.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ClipboardList } from 'lucide-react';
 import { FieldPluginProps, registerPlugin } from './FieldPlugin';
 
 // A small inner field preview row used inside the repeater section
@@ -58,7 +59,12 @@ const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                     borderBottom: '1px solid #c4b5fd',
                 }}
             >
-                📋 {field.label} — Item 1
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35rem' }}>
+                    <ClipboardList size={15} strokeWidth={2} aria-hidden />
+                    <span>
+                        {field.label} — Item 1
+                    </span>
+                </span>
             </div>
 
             {/* Child fields preview */}

--- a/formsync/frontend/src/builder/plugins/RepeaterFieldPreview.tsx
+++ b/formsync/frontend/src/builder/plugins/RepeaterFieldPreview.tsx
@@ -35,18 +35,37 @@ const InnerFieldRow: React.FC<{ label: string; type: string }> = ({ label, type 
     </div>
 );
 
+const theadCellStyle: React.CSSProperties = {
+    border: '1px solid #c4b5fd',
+    padding: '0.45rem 0.65rem',
+    textAlign: 'left',
+    fontWeight: 700,
+    fontSize: '0.78rem',
+    letterSpacing: '0.02em',
+    color: '#1e1b4b',
+    background: '#e9e5ff',
+};
+
+const bodyCellStyle: React.CSSProperties = {
+    border: '1px solid #ddd6fe',
+    padding: '0.4rem 0.5rem',
+    color: '#64748b',
+    fontSize: '0.75rem',
+};
+
 const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
     const children = field.children ?? [];
     const isTable = (field.ui as { displayMode?: string } | undefined)?.displayMode === 'table';
 
-    if (isTable && children.length > 0) {
+    if (isTable) {
+        const colCount = Math.max(children.length, 1);
         return (
             <div
                 style={{
                     border: '1px solid #c7d2fe',
                     borderRadius: 8,
                     overflow: 'hidden',
-                    background: '#f5f3ff',
+                    background: '#fafaff',
                     pointerEvents: 'none',
                 }}
             >
@@ -62,41 +81,93 @@ const RepeaterFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                 >
                     <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35rem' }}>
                         <ClipboardList size={15} strokeWidth={2} aria-hidden />
-                        <span>{field.label} (table)</span>
+                        <span>{field.label}</span>
+                        <span style={{ fontWeight: 500, opacity: 0.85 }}>(data table)</span>
                     </span>
                 </div>
                 <div style={{ overflowX: 'auto', padding: '0.5rem' }}>
-                    <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.72rem' }}>
+                    <table
+                        style={{
+                            width: '100%',
+                            borderCollapse: 'collapse',
+                            fontSize: '0.8125rem',
+                            background: '#fff',
+                            border: '1px solid #ddd6fe',
+                            borderRadius: 6,
+                            overflow: 'hidden',
+                        }}
+                    >
                         <thead>
-                            <tr style={{ background: '#faf5ff' }}>
-                                {children.map((c) => (
-                                    <th
-                                        key={c.id}
-                                        style={{
-                                            border: '1px solid #ddd6fe',
-                                            padding: '0.35rem 0.5rem',
-                                            textAlign: 'left',
-                                            fontWeight: 600,
-                                            color: '#4c1d95',
-                                        }}
-                                    >
-                                        {c.label}
+                            <tr>
+                                {children.length > 0 ? (
+                                    children.map((c) => (
+                                        <th key={c.id} scope="col" style={theadCellStyle}>
+                                            {c.label}
+                                            {c.required ? (
+                                                <span style={{ color: '#b91c1c', marginLeft: 2 }} aria-hidden="true">
+                                                    *
+                                                </span>
+                                            ) : null}
+                                        </th>
+                                    ))
+                                ) : (
+                                    <th scope="col" style={theadCellStyle}>
+                                        {/* Placeholder until user adds Year, Experience, etc. as child fields */}
+                                        Columns — add child fields (e.g. Year, Experience)
                                     </th>
-                                ))}
-                                <th style={{ border: '1px solid #ddd6fe', padding: '0.35rem', width: '4rem' }} />
+                                )}
+                                <th
+                                    scope="col"
+                                    style={{
+                                        ...theadCellStyle,
+                                        width: '5.5rem',
+                                        textAlign: 'right',
+                                        background: '#f5f3ff',
+                                    }}
+                                >
+                                    Actions
+                                </th>
                             </tr>
                         </thead>
                         <tbody>
-                            <tr>
-                                {children.map((c) => (
-                                    <td key={c.id} style={{ border: '1px solid #e9d5ff', padding: '0.35rem', color: '#9ca3af', fontStyle: 'italic' }}>
-                                        {c.type}
+                            {children.length > 0 ? (
+                                <tr>
+                                    {children.map((c) => (
+                                        <td key={c.id} style={{ ...bodyCellStyle, fontStyle: 'italic' }}>
+                                            {c.type}
+                                        </td>
+                                    ))}
+                                    <td
+                                        style={{
+                                            ...bodyCellStyle,
+                                            textAlign: 'right',
+                                            fontSize: '0.7rem',
+                                            color: '#7c3aed',
+                                            fontWeight: 600,
+                                            fontStyle: 'normal',
+                                        }}
+                                    >
+                                        Remove
                                     </td>
-                                ))}
-                                <td style={{ border: '1px solid #e9d5ff', padding: '0.35rem', textAlign: 'right', fontSize: '0.65rem', color: '#7c3aed' }}>
-                                    Remove
-                                </td>
-                            </tr>
+                                </tr>
+                            ) : (
+                                <tr>
+                                    <td
+                                        colSpan={colCount + 1}
+                                        style={{
+                                            ...bodyCellStyle,
+                                            textAlign: 'center',
+                                            padding: '0.85rem',
+                                            background: '#faf5ff',
+                                            color: '#5b21b6',
+                                            fontStyle: 'normal',
+                                        }}
+                                    >
+                                        Select this repeater → <strong>Properties</strong> → add each column as a
+                                        child field. Labels become the table headings.
+                                    </td>
+                                </tr>
+                            )}
                         </tbody>
                     </table>
                 </div>

--- a/formsync/frontend/src/builder/plugins/RichTextFieldPreview.tsx
+++ b/formsync/frontend/src/builder/plugins/RichTextFieldPreview.tsx
@@ -1,76 +1,84 @@
 import React from 'react';
 import { Link2, List, ListOrdered } from 'lucide-react';
 import { FieldPluginProps, registerPlugin } from './FieldPlugin';
+import { resolveFieldStyleOverrides } from './fieldPreviewStyles';
 
-const toolbarBtn: React.CSSProperties = {
-    fontSize: '0.78rem',
-    padding: '2px 6px',
-    border: '1px solid #d1d5db',
-    borderRadius: 3,
-    background: '#fff',
-    color: '#374151',
-    fontFamily: 'inherit',
-    fontWeight: 600,
-    cursor: 'default',
-    lineHeight: 1.2,
-};
+const RichTextFieldPreview: React.FC<FieldPluginProps> = ({ field, theme }) => {
+    const { border, surface, hint, accent } = resolveFieldStyleOverrides(field, theme);
+    const toolbarBg = `color-mix(in srgb, ${accent} 10%, ${surface})`;
 
-const RichTextFieldPreview: React.FC<FieldPluginProps> = ({ field }) => (
-    <div
-        style={{
-            border: '1px solid var(--color-border, #e5e7eb)',
-            borderRadius: 6,
-            overflow: 'hidden',
-            pointerEvents: 'none',
-        }}
-    >
+    const toolbarBtn = (extra?: React.CSSProperties): React.CSSProperties => ({
+        fontSize: '0.78rem',
+        padding: '2px 6px',
+        border: `1px solid ${border}`,
+        borderRadius: 3,
+        background: surface,
+        color: hint,
+        fontFamily: 'inherit',
+        fontWeight: 600,
+        cursor: 'default',
+        lineHeight: 1.2,
+        ...extra,
+    });
+
+    return (
         <div
             style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '0.25rem',
-                padding: '0.4rem 0.75rem',
-                borderBottom: '1px solid #e5e7eb',
-                background: '#f9fafb',
+                border: `1px solid ${border}`,
+                borderRadius: 6,
+                overflow: 'hidden',
+                pointerEvents: 'none',
             }}
         >
-            <span style={toolbarBtn}>B</span>
-            <span style={toolbarBtn}>I</span>
-            <span style={toolbarBtn}>U</span>
-            <span
+            <div
                 style={{
-                    width: 1,
-                    alignSelf: 'stretch',
-                    minHeight: 14,
-                    background: '#e5e7eb',
-                    margin: '0 2px',
-                    flexShrink: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.25rem',
+                    padding: '0.4rem 0.75rem',
+                    borderBottom: `1px solid ${border}`,
+                    background: toolbarBg,
                 }}
-                aria-hidden
-            />
-            <span style={{ ...toolbarBtn, display: 'inline-flex', alignItems: 'center', padding: '2px 5px' }} aria-hidden>
-                <List size={12} strokeWidth={2} />
-            </span>
-            <span style={{ ...toolbarBtn, display: 'inline-flex', alignItems: 'center', padding: '2px 5px' }} aria-hidden>
-                <ListOrdered size={12} strokeWidth={2} />
-            </span>
-            <span style={{ ...toolbarBtn, display: 'inline-flex', alignItems: 'center', padding: '2px 5px' }} aria-hidden>
-                <Link2 size={12} strokeWidth={2} />
-            </span>
+            >
+                <span style={toolbarBtn()}>B</span>
+                <span style={toolbarBtn()}>I</span>
+                <span style={toolbarBtn()}>U</span>
+                <span
+                    style={{
+                        width: 1,
+                        alignSelf: 'stretch',
+                        minHeight: 14,
+                        background: border,
+                        margin: '0 2px',
+                        flexShrink: 0,
+                    }}
+                    aria-hidden
+                />
+                <span style={{ ...toolbarBtn(), display: 'inline-flex', alignItems: 'center', padding: '2px 5px' }} aria-hidden>
+                    <List size={12} strokeWidth={2} />
+                </span>
+                <span style={{ ...toolbarBtn(), display: 'inline-flex', alignItems: 'center', padding: '2px 5px' }} aria-hidden>
+                    <ListOrdered size={12} strokeWidth={2} />
+                </span>
+                <span style={{ ...toolbarBtn(), display: 'inline-flex', alignItems: 'center', padding: '2px 5px', color: accent }} aria-hidden>
+                    <Link2 size={12} strokeWidth={2} />
+                </span>
+            </div>
+            <div
+                style={{
+                    padding: '0.75rem',
+                    minHeight: '80px',
+                    background: surface,
+                    color: hint,
+                    fontStyle: 'italic',
+                    fontSize: '0.875rem',
+                }}
+            >
+                {field.ui?.placeholder ?? 'Start typing rich content here…'}
+            </div>
         </div>
-        <div
-            style={{
-                padding: '0.75rem',
-                minHeight: '80px',
-                color: '#9ca3af',
-                fontStyle: 'italic',
-                fontSize: '0.875rem',
-            }}
-        >
-            {field.ui?.placeholder ?? 'Start typing rich content here…'}
-        </div>
-    </div>
-);
+    );
+};
 
 registerPlugin('richtext', RichTextFieldPreview);
 export { RichTextFieldPreview };

--- a/formsync/frontend/src/builder/plugins/RichTextFieldPreview.tsx
+++ b/formsync/frontend/src/builder/plugins/RichTextFieldPreview.tsx
@@ -1,5 +1,19 @@
 import React from 'react';
+import { Link2, List, ListOrdered } from 'lucide-react';
 import { FieldPluginProps, registerPlugin } from './FieldPlugin';
+
+const toolbarBtn: React.CSSProperties = {
+    fontSize: '0.78rem',
+    padding: '2px 6px',
+    border: '1px solid #d1d5db',
+    borderRadius: 3,
+    background: '#fff',
+    color: '#374151',
+    fontFamily: 'inherit',
+    fontWeight: 600,
+    cursor: 'default',
+    lineHeight: 1.2,
+};
 
 const RichTextFieldPreview: React.FC<FieldPluginProps> = ({ field }) => (
     <div
@@ -10,35 +24,40 @@ const RichTextFieldPreview: React.FC<FieldPluginProps> = ({ field }) => (
             pointerEvents: 'none',
         }}
     >
-        {/* Mock toolbar */}
         <div
             style={{
                 display: 'flex',
+                alignItems: 'center',
                 gap: '0.25rem',
                 padding: '0.4rem 0.75rem',
                 borderBottom: '1px solid #e5e7eb',
                 background: '#f9fafb',
             }}
         >
-            {['B', 'I', 'U', '—', '≡', '≡≡', '—', '🔗'].map((t, i) => (
-                <span
-                    key={i}
-                    style={{
-                        fontSize: '0.78rem',
-                        padding: '2px 5px',
-                        border: '1px solid #d1d5db',
-                        borderRadius: 3,
-                        background: '#fff',
-                        color: '#374151',
-                        fontFamily: 'serif',
-                        cursor: 'default',
-                    }}
-                >
-                    {t}
-                </span>
-            ))}
+            <span style={toolbarBtn}>B</span>
+            <span style={toolbarBtn}>I</span>
+            <span style={toolbarBtn}>U</span>
+            <span
+                style={{
+                    width: 1,
+                    alignSelf: 'stretch',
+                    minHeight: 14,
+                    background: '#e5e7eb',
+                    margin: '0 2px',
+                    flexShrink: 0,
+                }}
+                aria-hidden
+            />
+            <span style={{ ...toolbarBtn, display: 'inline-flex', alignItems: 'center', padding: '2px 5px' }} aria-hidden>
+                <List size={12} strokeWidth={2} />
+            </span>
+            <span style={{ ...toolbarBtn, display: 'inline-flex', alignItems: 'center', padding: '2px 5px' }} aria-hidden>
+                <ListOrdered size={12} strokeWidth={2} />
+            </span>
+            <span style={{ ...toolbarBtn, display: 'inline-flex', alignItems: 'center', padding: '2px 5px' }} aria-hidden>
+                <Link2 size={12} strokeWidth={2} />
+            </span>
         </div>
-        {/* Mock content area */}
         <div
             style={{
                 padding: '0.75rem',

--- a/formsync/frontend/src/builder/plugins/SignatureFieldPreview.tsx
+++ b/formsync/frontend/src/builder/plugins/SignatureFieldPreview.tsx
@@ -1,63 +1,65 @@
 import React from 'react';
 import { PenLine } from 'lucide-react';
 import { FieldPluginProps, registerPlugin } from './FieldPlugin';
+import { resolveFieldStyleOverrides } from './fieldPreviewStyles';
 
-const SignatureFieldPreview: React.FC<FieldPluginProps> = () => (
-    <div
-        style={{
-            border: '1px solid #d1d5db',
-            borderRadius: 8,
-            background: '#f9fafb',
-            height: '100px',
-            position: 'relative',
-            overflow: 'hidden',
-            pointerEvents: 'none',
-        }}
-    >
-        {/* Baseline */}
+const SignatureFieldPreview: React.FC<FieldPluginProps> = ({ field, theme }) => {
+    const { border, surface, hint } = resolveFieldStyleOverrides(field, theme);
+    return (
         <div
             style={{
-                position: 'absolute',
-                bottom: '28px',
-                left: '5%',
-                right: '5%',
-                borderBottom: '1px dashed #9ca3af',
-            }}
-        />
-        {/* Placeholder text */}
-        <div
-            style={{
-                position: 'absolute',
-                inset: 0,
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: '0.25rem',
+                border: `1px solid ${border}`,
+                borderRadius: 8,
+                background: surface,
+                height: '100px',
+                position: 'relative',
+                overflow: 'hidden',
+                pointerEvents: 'none',
             }}
         >
-            <PenLine size={22} strokeWidth={1.75} color="#9ca3af" aria-hidden />
-            <span style={{ fontSize: '0.78rem', color: '#9ca3af' }}>Sign here</span>
+            <div
+                style={{
+                    position: 'absolute',
+                    bottom: '28px',
+                    left: '5%',
+                    right: '5%',
+                    borderBottom: `1px dashed ${hint}`,
+                }}
+            />
+            <div
+                style={{
+                    position: 'absolute',
+                    inset: 0,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: '0.25rem',
+                }}
+            >
+                <PenLine size={22} strokeWidth={1.75} color={hint} aria-hidden />
+                <span style={{ fontSize: '0.78rem', color: hint }}>Sign here</span>
+            </div>
+            <button
+                type="button"
+                style={{
+                    position: 'absolute',
+                    bottom: '6px',
+                    right: '8px',
+                    fontSize: '0.7rem',
+                    padding: '2px 8px',
+                    border: `1px solid ${border}`,
+                    borderRadius: 4,
+                    background: surface,
+                    color: hint,
+                    cursor: 'default',
+                }}
+            >
+                Clear
+            </button>
         </div>
-        {/* Clear button mock */}
-        <button
-            style={{
-                position: 'absolute',
-                bottom: '6px',
-                right: '8px',
-                fontSize: '0.7rem',
-                padding: '2px 8px',
-                border: '1px solid #d1d5db',
-                borderRadius: 4,
-                background: '#fff',
-                color: '#6b7280',
-                cursor: 'default',
-            }}
-        >
-            Clear
-        </button>
-    </div>
-);
+    );
+};
 
 registerPlugin('signature', SignatureFieldPreview);
 export { SignatureFieldPreview };

--- a/formsync/frontend/src/builder/plugins/SignatureFieldPreview.tsx
+++ b/formsync/frontend/src/builder/plugins/SignatureFieldPreview.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { PenLine } from 'lucide-react';
 import { FieldPluginProps, registerPlugin } from './FieldPlugin';
 
 const SignatureFieldPreview: React.FC<FieldPluginProps> = () => (
@@ -35,7 +36,7 @@ const SignatureFieldPreview: React.FC<FieldPluginProps> = () => (
                 gap: '0.25rem',
             }}
         >
-            <span style={{ fontSize: '1.5rem' }}>✍️</span>
+            <PenLine size={22} strokeWidth={1.75} color="#9ca3af" aria-hidden />
             <span style={{ fontSize: '0.78rem', color: '#9ca3af' }}>Sign here</span>
         </div>
         {/* Clear button mock */}

--- a/formsync/frontend/src/builder/plugins/TypeaheadFieldPreview.tsx
+++ b/formsync/frontend/src/builder/plugins/TypeaheadFieldPreview.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Search } from 'lucide-react';
 import { FieldPluginProps, registerPlugin } from './FieldPlugin';
 
 const TypeaheadFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
@@ -24,8 +25,7 @@ const TypeaheadFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                     gap: '0.5rem',
                 }}
             >
-                {/* Search icon */}
-                <span style={{ color: '#9ca3af', fontSize: '0.9rem' }}>🔍</span>
+                <Search size={16} strokeWidth={2} style={{ color: '#9ca3af', flexShrink: 0 }} aria-hidden />
                 <span
                     style={{
                         flex: 1,
@@ -79,7 +79,7 @@ const TypeaheadFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                     color: '#9ca3af',
                 }}
             >
-                ↳ Results will appear here after typing
+                Results appear below when you type.
             </div>
         </div>
     );

--- a/formsync/frontend/src/builder/plugins/TypeaheadFieldPreview.tsx
+++ b/formsync/frontend/src/builder/plugins/TypeaheadFieldPreview.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { Search } from 'lucide-react';
 import { FieldPluginProps, registerPlugin } from './FieldPlugin';
+import { resolveFieldStyleOverrides } from './fieldPreviewStyles';
 
-const TypeaheadFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
+const TypeaheadFieldPreview: React.FC<FieldPluginProps> = ({ field, theme }) => {
     const src = field.ui?.['x-ui']?.asyncSource;
     const hasUrl = src?.url && src.url.length > 0;
+    const { border, surface, hint, accent } = resolveFieldStyleOverrides(field, theme);
 
     return (
         <div
@@ -17,34 +19,33 @@ const TypeaheadFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                 style={{
                     display: 'flex',
                     alignItems: 'center',
-                    border: '1px solid #d1d5db',
+                    border: `1px solid ${border}`,
                     borderRadius: 6,
-                    background: '#fff',
+                    background: surface,
                     padding: '0 0.75rem',
                     height: '38px',
                     gap: '0.5rem',
                 }}
             >
-                <Search size={16} strokeWidth={2} style={{ color: '#9ca3af', flexShrink: 0 }} aria-hidden />
+                <Search size={16} strokeWidth={2} style={{ color: hint, flexShrink: 0 }} aria-hidden />
                 <span
                     style={{
                         flex: 1,
                         fontSize: '0.875rem',
-                        color: '#9ca3af',
+                        color: hint,
                         fontStyle: 'italic',
                     }}
                 >
                     {field.ui?.placeholder ?? 'Type to search…'}
                 </span>
-                {/* Loading spinner indicator */}
                 {hasUrl && (
                     <span
                         title={`Fetches from: ${src?.url}`}
                         style={{
                             fontSize: '0.7rem',
                             padding: '2px 6px',
-                            background: '#dbeafe',
-                            color: '#1d4ed8',
+                            background: `color-mix(in srgb, ${accent} 15%, ${surface})`,
+                            color: accent,
                             borderRadius: 10,
                             fontWeight: 600,
                         }}
@@ -57,8 +58,8 @@ const TypeaheadFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                         style={{
                             fontSize: '0.7rem',
                             padding: '2px 6px',
-                            background: '#fef3c7',
-                            color: '#b45309',
+                            background: `color-mix(in srgb, ${accent} 12%, ${surface})`,
+                            color: hint,
                             borderRadius: 10,
                             fontWeight: 600,
                         }}
@@ -67,16 +68,15 @@ const TypeaheadFieldPreview: React.FC<FieldPluginProps> = ({ field }) => {
                     </span>
                 )}
             </div>
-            {/* Dropdown hint */}
             <div
                 style={{
-                    border: '1px solid #e5e7eb',
+                    border: `1px solid ${border}`,
                     borderTop: 'none',
                     borderRadius: '0 0 6px 6px',
-                    background: '#fff',
+                    background: surface,
                     padding: '0.4rem 0.75rem',
                     fontSize: '0.78rem',
-                    color: '#9ca3af',
+                    color: hint,
                 }}
             >
                 Results appear below when you type.

--- a/formsync/frontend/src/builder/plugins/fieldPreviewStyles.ts
+++ b/formsync/frontend/src/builder/plugins/fieldPreviewStyles.ts
@@ -1,0 +1,21 @@
+import type { FieldModel } from '../../types';
+
+type Ov = Record<string, string>;
+
+/**
+ * Style Overrides from the right panel, with theme fallbacks (same keys as Canvas / GenericFieldMock).
+ */
+export function resolveFieldStyleOverrides(
+    field: FieldModel,
+    theme: Record<string, string | number>,
+) {
+    const o = field.ui?.styleOverrides as Ov | undefined;
+    const t = theme as Record<string, string>;
+    return {
+        border: o?.borderColor ?? t['--color-border'] ?? '#e2e8f0',
+        surface: o?.backgroundColor ?? t['--color-input-bg'] ?? '#ffffff',
+        label: o?.labelColor ?? t['--color-text'] ?? '#0f172a',
+        hint: o?.inputTextColor ?? t['--color-muted'] ?? '#64748b',
+        accent: o?.focusColor ?? t['--color-primary'] ?? '#6366f1',
+    };
+}

--- a/formsync/frontend/src/components/FrontendStackSelector.tsx
+++ b/formsync/frontend/src/components/FrontendStackSelector.tsx
@@ -56,7 +56,10 @@ export const FrontendStackSelector: React.FC<FrontendStackSelectorProps> = ({
 }) => {
   return (
     <div
-      className={cn("grid w-full grid-cols-1 gap-2 sm:grid-cols-2 sm:gap-3", className)}
+      className={cn(
+        "grid w-full grid-cols-3 gap-2 sm:gap-3",
+        className,
+      )}
       role="radiogroup"
       aria-label="Frontend generation stack"
     >
@@ -71,31 +74,53 @@ export const FrontendStackSelector: React.FC<FrontendStackSelectorProps> = ({
             role="radio"
             aria-checked={isSelected}
             onClick={() => onChange(opt.id)}
-            whileHover={{ scale: 1.01 }}
-            whileTap={{ scale: 0.99 }}
             className={cn(
-              "relative flex flex-col items-start gap-2 rounded-xl border-2 p-4 text-left transition-colors",
+              "relative flex min-w-0 w-full items-center gap-2 sm:gap-3 px-2 py-3 sm:px-4 rounded-xl transition-all duration-200",
+              "border-2 cursor-pointer group",
+              isSelected
+                ? `${opt.borderColor} shadow-lg scale-[1.02]`
+                : `border-neutral-200 dark:border-neutral-700 ${opt.hoverBorderColor}`,
               opt.bgColor,
-              isSelected ? opt.borderColor : "border-transparent",
-              opt.hoverBorderColor,
             )}
+            whileHover={{ y: -2 }}
+            whileTap={{ scale: 0.98 }}
           >
             <div
               className={cn(
-                "flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-br text-white shadow-sm",
-                opt.color,
+                "w-10 h-10 rounded-lg flex items-center justify-center shrink-0",
+                isSelected &&
+                  `bg-gradient-to-br ${opt.color} text-white shadow-md`,
+                !isSelected &&
+                  "bg-white dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400",
               )}
             >
-              <Icon className="h-5 w-5" />
+              <Icon className="w-5 h-5" />
             </div>
-            <div>
-              <div className={cn("font-semibold", opt.textColor)}>{opt.label}</div>
-              <p className="text-xs text-neutral-600 dark:text-neutral-400">
+
+            <div className="text-left min-w-0">
+              <div
+                className={cn(
+                  "font-semibold text-sm",
+                  isSelected
+                    ? opt.textColor
+                    : "text-neutral-700 dark:text-neutral-300",
+                )}
+              >
+                {opt.label}
+              </div>
+              <div className="text-xs text-neutral-500 dark:text-neutral-500 line-clamp-2">
                 {opt.description}
-              </p>
+              </div>
             </div>
+
             {isSelected && (
-              <span className="absolute right-3 top-3 h-2 w-2 rounded-full bg-current opacity-80" />
+              <motion.div
+                initial={{ scale: 0 }}
+                animate={{ scale: 1 }}
+                className={`absolute -top-1 -right-1 w-6 h-6 bg-gradient-to-br ${opt.color} rounded-full flex items-center justify-center shadow-lg`}
+              >
+                <span className="text-white text-xs font-bold">✓</span>
+              </motion.div>
             )}
           </motion.button>
         );

--- a/formsync/frontend/src/components/shared/FlowDiagram.tsx
+++ b/formsync/frontend/src/components/shared/FlowDiagram.tsx
@@ -7,16 +7,39 @@ interface PipelineStage {
   status: "pending" | "loading" | "complete" | "error";
 }
 
-interface FlowDiagramProps {
+export interface FlowDiagramProps {
   stages: PipelineStage[];
+  /**
+   * `card` — padded panel with border (pages, marketing-style).
+   * `strip` — dense single-row pipeline for the form builder toolbar (no card chrome).
+   */
+  variant?: "card" | "strip";
 }
 
-export const FlowDiagram: React.FC<FlowDiagramProps> = ({ stages }) => {
+export const FlowDiagram: React.FC<FlowDiagramProps> = ({
+  stages,
+  variant = "card",
+}) => {
   const completedCount = stages.filter((s) => s.status === "complete").length;
+  const strip = variant === "strip";
+
+  const outerClass = strip
+    ? "w-full min-w-0 bg-transparent py-0.5"
+    : "px-8 py-6 bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-800 shadow-sm";
+
+  const nodeSize = strip ? "w-7 h-7 border-2" : "w-9 h-9 border-2";
+  const iconClass = strip ? "h-3.5 w-3.5" : "h-4 w-4";
+  const numClass = strip
+    ? "text-[10px] font-semibold"
+    : "text-xs font-semibold";
+  const labelClass = strip ? "text-[10px]" : "text-[11px]";
+  const colGap = strip ? "gap-1.5" : "gap-2.5";
+  const connectorMb = strip ? "mb-5" : "mb-7";
+  const connectorMx = strip ? "mx-0.5" : "mx-1";
 
   return (
-    <div className="px-8 py-6 bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-800 shadow-sm">
-      <div className="flex items-center">
+    <div className={outerClass}>
+      <div className="flex min-w-0 items-center">
         {stages.map((stage, index) => {
           const isComplete = stage.status === "complete";
           const isLoading = stage.status === "loading";
@@ -26,8 +49,9 @@ export const FlowDiagram: React.FC<FlowDiagramProps> = ({ stages }) => {
 
           return (
             <React.Fragment key={stage.name}>
-              {/* Node + Label */}
-              <div className="flex flex-col items-center gap-2.5 flex-shrink-0">
+              <div
+                className={`flex min-w-0 flex-col items-center ${colGap} flex-shrink-0`}
+              >
                 <motion.div
                   initial={{ scale: 0.7, opacity: 0 }}
                   animate={{ scale: 1, opacity: 1 }}
@@ -37,7 +61,7 @@ export const FlowDiagram: React.FC<FlowDiagramProps> = ({ stages }) => {
                     ease: "easeOut",
                   }}
                   className={`
-                    relative w-9 h-9 rounded-full border-2 flex items-center justify-center
+                    relative ${nodeSize} rounded-full flex items-center justify-center
                     transition-all duration-300
                     ${
                       isComplete
@@ -60,7 +84,7 @@ export const FlowDiagram: React.FC<FlowDiagramProps> = ({ stages }) => {
                         transition={{ duration: 0.15 }}
                       >
                         <Check
-                          className="h-4 w-4 text-white"
+                          className={`${iconClass} text-white`}
                           strokeWidth={2.5}
                         />
                       </motion.div>
@@ -73,7 +97,9 @@ export const FlowDiagram: React.FC<FlowDiagramProps> = ({ stages }) => {
                         exit={{ scale: 0 }}
                         transition={{ duration: 0.15 }}
                       >
-                        <Loader2 className="h-4 w-4 text-white animate-spin" />
+                        <Loader2
+                          className={`${iconClass} text-white animate-spin`}
+                        />
                       </motion.div>
                     )}
                     {isError && (
@@ -84,7 +110,7 @@ export const FlowDiagram: React.FC<FlowDiagramProps> = ({ stages }) => {
                         exit={{ scale: 0 }}
                         transition={{ duration: 0.15 }}
                       >
-                        <AlertCircle className="h-4 w-4 text-white" />
+                        <AlertCircle className={`${iconClass} text-white`} />
                       </motion.div>
                     )}
                     {!isComplete && !isLoading && !isError && (
@@ -94,9 +120,11 @@ export const FlowDiagram: React.FC<FlowDiagramProps> = ({ stages }) => {
                         animate={{ scale: 1 }}
                         exit={{ scale: 0 }}
                         transition={{ duration: 0.15 }}
-                        className="w-full h-full flex items-center justify-center"
+                        className="flex h-full w-full items-center justify-center"
                       >
-                        <span className="text-xs font-semibold leading-none text-neutral-400 dark:text-neutral-500 select-none">
+                        <span
+                          className={`${numClass} leading-none text-neutral-400 dark:text-neutral-500 select-none`}
+                        >
                           {index + 1}
                         </span>
                       </motion.div>
@@ -104,9 +132,8 @@ export const FlowDiagram: React.FC<FlowDiagramProps> = ({ stages }) => {
                   </AnimatePresence>
                 </motion.div>
 
-                {/* Label */}
                 <span
-                  className={`text-[11px] font-medium text-center leading-tight whitespace-nowrap transition-colors duration-300 ${
+                  className={`${labelClass} max-w-[5.5rem] truncate font-medium text-center leading-tight sm:max-w-none sm:whitespace-nowrap transition-colors duration-300 ${
                     isComplete
                       ? "text-emerald-600 dark:text-emerald-400"
                       : isLoading
@@ -115,16 +142,18 @@ export const FlowDiagram: React.FC<FlowDiagramProps> = ({ stages }) => {
                           ? "text-red-500"
                           : "text-neutral-400 dark:text-neutral-500"
                   }`}
+                  title={stage.name}
                 >
                   {stage.name}
                 </span>
               </div>
 
-              {/* Connector line between nodes */}
               {!isLast && (
-                <div className="flex-1 mx-1 mb-7 relative h-0.5 rounded-full bg-neutral-200 dark:bg-neutral-700 overflow-hidden">
+                <div
+                  className={`relative flex-1 ${connectorMx} ${connectorMb} h-0.5 overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-700`}
+                >
                   <motion.div
-                    className="absolute inset-y-0 left-0 bg-gradient-to-r from-emerald-500 to-emerald-400 rounded-full"
+                    className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-emerald-500 to-emerald-400"
                     initial={{ width: "0%" }}
                     animate={{ width: connectorFilled ? "100%" : "0%" }}
                     transition={{

--- a/formsync/frontend/src/context/BuilderContext.tsx
+++ b/formsync/frontend/src/context/BuilderContext.tsx
@@ -398,15 +398,22 @@ function uniqueSemanticFieldKey(
     return `${stem}${n}`;
 }
 
+/** Optional defaults when inserting from the palette (e.g. repeater shown as a data table). */
+export type CreateFieldOptions = {
+    repeaterAsTable?: boolean;
+};
+
 /** Creates a new FieldModel with sensible defaults for a given type */
 export function createField(
     type: FieldType,
     stepIndex?: number,
     existingKeys?: Iterable<string>,
+    options?: CreateFieldOptions,
 ): FieldModel {
     const taken = new Set(existingKeys ?? []);
     const id = `field-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
-    const baseLabel = labelForType(type);
+    const repeaterAsTable = type === 'repeater' && options?.repeaterAsTable === true;
+    const baseLabel = repeaterAsTable ? 'Repeating table' : labelForType(type);
     const key = uniqueSemanticFieldKey(baseLabel, type, taken);
     const base: FieldModel = {
         id,
@@ -414,9 +421,11 @@ export function createField(
         type,
         label: baseLabel,
         required: false,
-        ui: {
-            placeholder: `Enter ${baseLabel.toLowerCase()}...`
-        },
+        ui: repeaterAsTable
+            ? { displayMode: 'table' }
+            : {
+                  placeholder: `Enter ${baseLabel.toLowerCase()}...`,
+              },
         ...(stepIndex !== undefined ? { stepIndex } : {}),
     };
 

--- a/formsync/frontend/src/lib/conditionEngine.ts
+++ b/formsync/frontend/src/lib/conditionEngine.ts
@@ -11,6 +11,54 @@
 
 import type { FieldModel, ConditionRule, ConditionOperator } from '../types';
 
+/**
+ * Top-level field list for one wizard step. Groups/repeaters are kept only if they
+ * contain at least one leaf whose effective step matches; nested leaves use stepIndex ?? 0.
+ */
+export function pruneFieldsForWizardStep(fields: FieldModel[], stepIdx: number): FieldModel[] {
+    const out: FieldModel[] = [];
+    for (const f of fields) {
+        if (f.type === 'group' && f.children?.length) {
+            const children = pruneFieldsForWizardStep(f.children, stepIdx);
+            if (children.length > 0) {
+                out.push({ ...f, children });
+            }
+            continue;
+        }
+        if (f.type === 'repeater' && f.children?.length) {
+            const children = pruneFieldsForWizardStep(f.children, stepIdx);
+            if (children.length > 0) {
+                out.push({ ...f, children });
+            }
+            continue;
+        }
+        if ((f.stepIndex ?? 0) === stepIdx) {
+            out.push(f);
+        }
+    }
+    return out;
+}
+
+function filterFieldTreeByCondition(field: FieldModel, values: FormValues): FieldModel | null {
+    if (field.type === 'group' && field.children?.length) {
+        const children = field.children
+            .map((c) => filterFieldTreeByCondition(c, values))
+            .filter((c): c is FieldModel => c !== null);
+        if (children.length === 0) return null;
+        if (!evaluateCondition(field, values)) return null;
+        return { ...field, children };
+    }
+    if (field.type === 'repeater' && field.children?.length) {
+        const children = field.children
+            .map((c) => filterFieldTreeByCondition(c, values))
+            .filter((c): c is FieldModel => c !== null);
+        if (children.length === 0) return null;
+        if (!evaluateCondition(field, values)) return null;
+        return { ...field, children };
+    }
+    return evaluateCondition(field, values) ? field : null;
+}
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 /** A snapshot of all current form values, keyed by fieldKey */
@@ -149,11 +197,9 @@ export function filterVisibleFields(
     values: FormValues,
     activeStep?: number,
 ): FieldModel[] {
-    return fields.filter((field) => {
-        // Step filter: if a step is active and field has a stepIndex, only show matching
-        if (activeStep !== undefined && field.stepIndex !== undefined) {
-            if (field.stepIndex !== activeStep) return false;
-        }
-        return evaluateCondition(field, values);
-    });
+    const afterStep =
+        activeStep === undefined ? fields : pruneFieldsForWizardStep(fields, activeStep);
+    return afterStep
+        .map((f) => filterFieldTreeByCondition(f, values))
+        .filter((f): f is FieldModel => f !== null);
 }

--- a/formsync/frontend/src/lib/nestedRepeaterGuard.ts
+++ b/formsync/frontend/src/lib/nestedRepeaterGuard.ts
@@ -1,0 +1,26 @@
+import { toast } from 'sonner';
+import type { FieldModel } from '../types';
+
+/** True if any repeater appears inside another repeater (or inside a group within a repeater). */
+export function formHasNestedRepeater(fields: FieldModel[]): boolean {
+    function walk(nodes: FieldModel[], withinRepeater: boolean): boolean {
+        for (const n of nodes) {
+            if (n.type === 'repeater') {
+                if (withinRepeater) return true;
+                if (n.children?.length && walk(n.children, true)) return true;
+            } else if (n.children?.length && walk(n.children, withinRepeater)) return true;
+        }
+        return false;
+    }
+    return walk(fields, false);
+}
+
+export function warnIfNestedRepeaterInForm(fields: FieldModel[]): void {
+    if (formHasNestedRepeater(fields)) {
+        toast.warning('Nested repeaters are not supported in export', {
+            description:
+                'React and static HTML generators only support one level of repeating blocks. Flatten repeaters inside repeaters or those sections will show a placeholder in generated code.',
+            duration: 9000,
+        });
+    }
+}

--- a/formsync/frontend/src/pages/BuilderPage.tsx
+++ b/formsync/frontend/src/pages/BuilderPage.tsx
@@ -10,6 +10,7 @@ import {
 import { BuilderLayout } from "../builder/BuilderLayout";
 import { FormModel, parseJsonSchemaToFormModel, type JsonSchema } from "../types";
 import { useAuth } from "../context/AuthContext";
+import { warnIfNestedRepeaterInForm } from "../lib/nestedRepeaterGuard";
 import "../builder/builder.css";
 
 function setSchemaIdInUrl(schemaId: string) {
@@ -52,6 +53,7 @@ const SchemaLoader: React.FC = () => {
         clearBuilderDraft();
         dispatch({ type: "SET_BASE_SCHEMA", payload: rawContent });
         dispatch({ type: "UPDATE_FORM", payload: formModel });
+        warnIfNestedRepeaterInForm(formModel.fields);
         dispatch({ type: "SET_SCHEMA_ID", payload: schemaId });
         setSchemaIdInUrl(schemaId);
         toast.dismiss();
@@ -82,6 +84,7 @@ const SchemaLoader: React.FC = () => {
             clearBuilderDraft();
             dispatch({ type: "SET_BASE_SCHEMA", payload: schema });
             dispatch({ type: "UPDATE_FORM", payload: formModel });
+            warnIfNestedRepeaterInForm(formModel.fields);
 
             if (user?.id) {
               try {
@@ -133,10 +136,12 @@ const SchemaLoader: React.FC = () => {
             schemaId?: string | null;
           };
           if (draft.form && typeof draft.form === "object") {
+            const restored = draft.form as FormModel;
             dispatch({
               type: "UPDATE_FORM",
-              payload: draft.form as FormModel,
+              payload: restored,
             });
+            warnIfNestedRepeaterInForm(restored.fields);
             if (typeof draft.activeStep === "number") {
               dispatch({ type: "SET_STEP", payload: draft.activeStep });
             }
@@ -163,6 +168,7 @@ const SchemaLoader: React.FC = () => {
           clearBuilderDraft();
           dispatch({ type: "SET_BASE_SCHEMA", payload: schema });
           dispatch({ type: "UPDATE_FORM", payload: formModel });
+          warnIfNestedRepeaterInForm(formModel.fields);
           toast.success("Schema loaded successfully");
           return;
         } catch {

--- a/formsync/frontend/src/pages/EditorPage.tsx
+++ b/formsync/frontend/src/pages/EditorPage.tsx
@@ -25,11 +25,13 @@ import { toast } from "sonner";
 import {
   generationService,
   type BackendLanguage,
+  type FrontendStack,
 } from "../services/generationService";
 import { useAuth } from "../context/AuthContext";
 import { FORMSYNC_BUILDER_SCHEMA_ID_KEY } from "../context/BuilderContext";
 import { projectApi } from "../api/projectApi";
 import { BackendLanguageSelector } from "../components/BackendLanguageSelector";
+import { FrontendStackSelector } from "../components/FrontendStackSelector";
 
 export interface GenerationStage {
   name: string;
@@ -47,6 +49,32 @@ export const EditorPage: React.FC = () => {
   const [activeTab, setActiveTab] = useState("technical"); // Control which tab is active
   const [backendLanguage, setBackendLanguage] =
     useState<BackendLanguage>("springBoot");
+  const [frontendStack, setFrontendStack] =
+    useState<FrontendStack>("react");
+
+  // Restore stack picks from session (defaults on /generated and after refresh)
+  useEffect(() => {
+    try {
+      const be = sessionStorage.getItem(
+        "formsync_backend_language",
+      ) as BackendLanguage | null;
+      if (
+        be === "nodeExpress" ||
+        be === "springBoot" ||
+        be === "dotnetWebApi"
+      ) {
+        setBackendLanguage(be);
+      }
+      const fe = sessionStorage.getItem(
+        "formsync_frontend_stack",
+      ) as FrontendStack | null;
+      if (fe === "react" || fe === "htmlBootstrap") {
+        setFrontendStack(fe);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
 
   // Tracks whether the schema was opened from a saved template (already enhanced)
   const [isLoadedFromTemplate, setIsLoadedFromTemplate] = useState(false);
@@ -212,11 +240,17 @@ export const EditorPage: React.FC = () => {
       if (result.success && result.data) {
         toast.success("Code generation complete!");
         sessionStorage.setItem("formsync_backend_language", backendLanguage);
-        navigate(`/generated?backendLanguage=${backendLanguage}`, {
+        sessionStorage.setItem("formsync_frontend_stack", frontendStack);
+        const genParams = new URLSearchParams({
+          backendLanguage,
+          frontendStack,
+        });
+        navigate(`/generated?${genParams.toString()}`, {
           state: {
             generatedCode: result.data,
             schema: currentSchema,
             backendLanguage,
+            frontendStack,
           },
         });
       } else {
@@ -368,20 +402,34 @@ export const EditorPage: React.FC = () => {
                 Define your data structure, validate and enhance it with AI,
                 then generate complete application code in one click.
               </p>
-              <div className="mt-6 max-w-3xl">
-                <label className="block text-xs font-bold uppercase tracking-widest text-neutral-800 dark:text-neutral-500 mb-2">
-                  Backend Language
-                </label>
-                <BackendLanguageSelector
-                  selected={backendLanguage}
-                  onChange={(selected) => {
-                    setBackendLanguage(selected);
-                    sessionStorage.setItem(
-                      "formsync_backend_language",
-                      selected,
-                    );
-                  }}
-                />
+              <div className="mt-6 max-w-3xl space-y-6">
+                <div>
+                  <label className="block text-xs font-bold uppercase tracking-widest text-neutral-800 dark:text-neutral-500 mb-2">
+                    Frontend Stack
+                  </label>
+                  <FrontendStackSelector
+                    selected={frontendStack}
+                    onChange={(stack) => {
+                      setFrontendStack(stack);
+                      sessionStorage.setItem("formsync_frontend_stack", stack);
+                    }}
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs font-bold uppercase tracking-widest text-neutral-800 dark:text-neutral-500 mb-2">
+                    Backend Language
+                  </label>
+                  <BackendLanguageSelector
+                    selected={backendLanguage}
+                    onChange={(selected) => {
+                      setBackendLanguage(selected);
+                      sessionStorage.setItem(
+                        "formsync_backend_language",
+                        selected,
+                      );
+                    }}
+                  />
+                </div>
               </div>
             </motion.div>
 

--- a/formsync/frontend/src/pages/GeneratedCodePage.tsx
+++ b/formsync/frontend/src/pages/GeneratedCodePage.tsx
@@ -35,6 +35,8 @@ interface LocationState {
   /** Fresh JSON Schema from Form Builder (preferred over re-fetch by schemaId). */
   schema?: any;
   backendLanguage?: BackendLanguage;
+  /** Defaults from Schema Editor / session; user can change on this page. */
+  frontendStack?: FrontendStack;
   /** Present when arriving from Form Builder so fullstack ZIP matches canvas customizations */
   formModel?: FormModel;
 }
@@ -135,6 +137,7 @@ export const GeneratedCodePage: React.FC = () => {
   const backendLanguageFromQuery = query.get(
     "backendLanguage",
   ) as BackendLanguage | null;
+  const frontendStackFromQuery = query.get("frontendStack");
 
   const [localState, setLocalState] = React.useState<LocationState | null>(
     (location.state as LocationState | null) ?? null,
@@ -149,10 +152,19 @@ export const GeneratedCodePage: React.FC = () => {
   const backendLanguageFromSession = sessionStorage.getItem(
     "formsync_backend_language",
   ) as BackendLanguage | null;
+  const routeStateInitial = location.state as LocationState | null;
   const initialBackendLanguage: BackendLanguage =
-    backendLanguageFromQuery ||
-    (location.state as LocationState | null)?.backendLanguage ||
-    backendLanguageFromSession ||
+    (backendLanguageFromQuery === "nodeExpress" ||
+    backendLanguageFromQuery === "springBoot" ||
+    backendLanguageFromQuery === "dotnetWebApi"
+      ? backendLanguageFromQuery
+      : null) ||
+    routeStateInitial?.backendLanguage ||
+    (backendLanguageFromSession === "nodeExpress" ||
+    backendLanguageFromSession === "springBoot" ||
+    backendLanguageFromSession === "dotnetWebApi"
+      ? backendLanguageFromSession
+      : null) ||
     "springBoot";
   const [backendLanguage, setBackendLanguage] =
     React.useState<BackendLanguage>(initialBackendLanguage);
@@ -160,8 +172,13 @@ export const GeneratedCodePage: React.FC = () => {
   const frontendStackFromSession = sessionStorage.getItem(
     "formsync_frontend_stack",
   ) as FrontendStack | null;
+  const parseFrontendStack = (v: string | null | undefined): FrontendStack | null =>
+    v === "react" || v === "htmlBootstrap" ? v : null;
   const initialFrontendStack: FrontendStack =
-    frontendStackFromSession === "htmlBootstrap" ? "htmlBootstrap" : "react";
+    parseFrontendStack(frontendStackFromQuery) ??
+    parseFrontendStack(routeStateInitial?.frontendStack) ??
+    parseFrontendStack(frontendStackFromSession) ??
+    "react";
   const [frontendStack, setFrontendStack] =
     React.useState<FrontendStack>(initialFrontendStack);
 
@@ -440,6 +457,18 @@ export const GeneratedCodePage: React.FC = () => {
             <div className="mt-4 max-w-3xl space-y-6">
               <div>
                 <label className="block text-xs font-bold uppercase tracking-widest text-neutral-800 dark:text-neutral-500 mb-2">
+                  Frontend Stack
+                </label>
+                <FrontendStackSelector
+                  selected={frontendStack}
+                  onChange={(stack) => {
+                    setFrontendStack(stack);
+                    sessionStorage.setItem("formsync_frontend_stack", stack);
+                  }}
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-bold uppercase tracking-widest text-neutral-800 dark:text-neutral-500 mb-2">
                   Backend Language
                 </label>
                 <BackendLanguageSelector
@@ -450,18 +479,6 @@ export const GeneratedCodePage: React.FC = () => {
                       "formsync_backend_language",
                       selected,
                     );
-                  }}
-                />
-              </div>
-              <div>
-                <label className="block text-xs font-bold uppercase tracking-widest text-neutral-800 dark:text-neutral-500 mb-2">
-                  Frontend Stack
-                </label>
-                <FrontendStackSelector
-                  selected={frontendStack}
-                  onChange={(stack) => {
-                    setFrontendStack(stack);
-                    sessionStorage.setItem("formsync_frontend_stack", stack);
                   }}
                 />
               </div>

--- a/formsync/frontend/src/pages/GeneratedCodePage.tsx
+++ b/formsync/frontend/src/pages/GeneratedCodePage.tsx
@@ -147,8 +147,6 @@ export const GeneratedCodePage: React.FC = () => {
     return !rs?.generatedCode;
   });
   const [isDownloadingBackend, setIsDownloadingBackend] = React.useState(false);
-  const [isDownloadingStaticFrontend, setIsDownloadingStaticFrontend] =
-    React.useState(false);
   const backendLanguageFromSession = sessionStorage.getItem(
     "formsync_backend_language",
   ) as BackendLanguage | null;
@@ -407,25 +405,6 @@ export const GeneratedCodePage: React.FC = () => {
     }
   };
 
-  const handleDownloadStaticFrontendOnly = async () => {
-    if (!state.formModel) {
-      toast.error(
-        "Open this page from the Form Builder with your form to download the HTML frontend.",
-      );
-      return;
-    }
-    setIsDownloadingStaticFrontend(true);
-    try {
-      await generationService.downloadStaticFrontendZip(state.formModel);
-      toast.success("Static HTML frontend downloaded!");
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : "Download failed";
-      toast.error(message);
-    } finally {
-      setIsDownloadingStaticFrontend(false);
-    }
-  };
-
   return (
     <PageTransition>
       <div className="flex flex-col min-h-screen bg-gradient-to-br from-neutral-50 via-white to-purple-50/30 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
@@ -481,19 +460,6 @@ export const GeneratedCodePage: React.FC = () => {
                     );
                   }}
                 />
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  disabled={isDownloadingStaticFrontend}
-                  onClick={() => void handleDownloadStaticFrontendOnly()}
-                >
-                  {isDownloadingStaticFrontend
-                    ? "Downloading…"
-                    : "Download HTML frontend only"}
-                </Button>
               </div>
             </div>
           </div>

--- a/formsync/frontend/src/services/generationService.ts
+++ b/formsync/frontend/src/services/generationService.ts
@@ -295,21 +295,32 @@ export const generationService = {
   };
 
   const onSubmit = async (data: ${componentName}Data) => {
-    const API_BASE_URL = import.meta.env.VITE_API_URL ?? "http://localhost:${defaultPort}";
-    const API_PATH = import.meta.env.VITE_API_PATH ?? ${JSON.stringify(apiPath)};
-    const jsonBody = stripEmptyJsonValues(data as unknown);
-    const res = await fetch(\`\${API_BASE_URL}\${API_PATH}\`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(jsonBody !== undefined ? jsonBody : {}),
-    });
-    if (!res.ok) {
-      throw new Error(\`Submit failed (\${res.status})\`);
+    setSubmitBanner(null);
+    try {
+      const API_BASE_URL = import.meta.env.VITE_API_URL ?? "http://localhost:${defaultPort}";
+      const API_PATH = import.meta.env.VITE_API_PATH ?? ${JSON.stringify(apiPath)};
+      const jsonBody = stripEmptyJsonValues(data as unknown);
+      const res = await fetch(\`\${API_BASE_URL}\${API_PATH}\`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(jsonBody !== undefined ? jsonBody : {}),
+      });
+      if (!res.ok) {
+        throw new Error(\`Submit failed (\${res.status})\`);
+      }
+      setSubmitBanner({
+        kind: "success",
+        message: "Submitted successfully.",
+      });
+    } catch (e: unknown) {
+      setSubmitBanner({
+        kind: "error",
+        message: e instanceof Error ? e.message : "Submit failed",
+      });
     }
-    alert("Submitted successfully");
   }`;
 
-    const frontend = `import React from 'react';
+    const frontend = `import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 interface ${componentName}Data {
@@ -318,11 +329,26 @@ ${tsInterface}
 
 export const ${componentName}: React.FC = () => {
   const { register, handleSubmit } = useForm<${componentName}Data>();
+  const [submitBanner, setSubmitBanner] = useState<
+    { kind: "success" | "error"; message: string } | null
+  >(null);
 
 ${onSubmitFn}
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      {submitBanner ? (
+        <div
+          role="alert"
+          className={
+            submitBanner.kind === "success"
+              ? "rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-900"
+              : "rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-900"
+          }
+        >
+          {submitBanner.message}
+        </div>
+      ) : null}
 ${formInputs}
       <button type="submit">Submit</button>
     </form>

--- a/formsync/frontend/src/test/conditionEngine.test.ts
+++ b/formsync/frontend/src/test/conditionEngine.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { evaluateCondition, evaluateCalcExpression, filterVisibleFields } from '../lib/conditionEngine';
+import { evaluateCondition, evaluateCalcExpression, filterVisibleFields, pruneFieldsForWizardStep } from '../lib/conditionEngine';
 import type { FieldModel } from '../types';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -149,6 +149,31 @@ describe('filterVisibleFields', () => {
         const result = filterVisibleFields([f1, f2], { name: 'Alice' }, 0);
         expect(result).toHaveLength(1);
         expect(result[0].key).toBe('name');
+    });
+
+    it('treats missing stepIndex as step 0 for wizard filtering', () => {
+        const unassigned = makeField({ id: 'fu', key: 'extra', type: 'text', label: 'Extra' });
+        expect(filterVisibleFields([unassigned], {}, 0)).toHaveLength(1);
+        expect(filterVisibleFields([unassigned], {}, 1)).toHaveLength(0);
+    });
+
+    it('pruneFieldsForWizardStep keeps groups when a nested child matches the step', () => {
+        const inner = makeField({ id: 'c1', key: 'child', type: 'text', label: 'Child', stepIndex: 1 });
+        const grp = makeField({
+            id: 'g1',
+            key: 'g',
+            type: 'group',
+            label: 'Group',
+            stepIndex: 0,
+            children: [inner],
+        });
+        const pruned0 = pruneFieldsForWizardStep([grp], 0);
+        expect(pruned0).toHaveLength(0);
+        const pruned1 = pruneFieldsForWizardStep([grp], 1);
+        expect(pruned1).toHaveLength(1);
+        expect(pruned1[0].type).toBe('group');
+        expect(pruned1[0].children).toHaveLength(1);
+        expect(pruned1[0].children![0].key).toBe('child');
     });
 
     it('filters by conditions within a step', () => {

--- a/formsync/packages/formgen-shared/src/react-wire.ts
+++ b/formsync/packages/formgen-shared/src/react-wire.ts
@@ -16,6 +16,7 @@ export function buildReactWiredSubmitReplacement(
   const apiPathEscaped = opts.apiPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
   return `/* FORMSYNC_API_SUBMIT_START */
     setStatusMessage('');
+    setSuccessModalOpen(false);
     try {
       const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:${opts.backendPort}";
       const API_PATH = import.meta.env.VITE_API_PATH || "${apiPathEscaped}";
@@ -168,13 +169,14 @@ export function buildReactWiredSubmitReplacement(
         throw new Error(\`Submission failed (\${response.status})\`);
       }
 
-      setStatusKind("success");
-      setStatusMessage(
+      setSuccessModalMessage(
         "Submitted successfully. Your response was sent to the server.",
       );
+      setSuccessModalOpen(true);
       console.log("Form submitted:", jsonBody !== undefined ? jsonBody : {});
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Submission failed";
+      setSuccessModalOpen(false);
       setStatusKind("error");
       setStatusMessage(msg);
     }

--- a/formsync/packages/formgen-shared/src/react-wire.ts
+++ b/formsync/packages/formgen-shared/src/react-wire.ts
@@ -168,10 +168,14 @@ export function buildReactWiredSubmitReplacement(
         throw new Error(\`Submission failed (\${response.status})\`);
       }
 
-      alert("Submitted successfully");
+      setStatusKind("success");
+      setStatusMessage(
+        "Submitted successfully. Your response was sent to the server.",
+      );
       console.log("Form submitted:", jsonBody !== undefined ? jsonBody : {});
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Submission failed";
+      setStatusKind("error");
       setStatusMessage(msg);
     }
     /* FORMSYNC_API_SUBMIT_END */`;

--- a/formsync/packages/formgen-shared/src/vanilla-submit.ts
+++ b/formsync/packages/formgen-shared/src/vanilla-submit.ts
@@ -16,7 +16,10 @@ export function buildVanillaWiredSubmitReplacement(
   const apiPathEsc = opts.apiPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
   return `/* FORMSYNC_API_SUBMIT_START */
     var statusEl = document.getElementById("form-status");
-    if (statusEl) statusEl.textContent = "";
+    if (statusEl) {
+      statusEl.textContent = "";
+      statusEl.className = "mb-3";
+    }
     try {
       var API_BASE_URL = "${apiBase}";
       var API_PATH = "${apiPathEsc}";
@@ -190,12 +193,19 @@ export function buildVanillaWiredSubmitReplacement(
         throw new Error("Submission failed (" + response.status + ")");
       }
 
-      alert("Submitted successfully");
+      if (statusEl) {
+        statusEl.textContent =
+          "Submitted successfully. Your response was sent to the server.";
+        statusEl.className = "alert alert-success mb-3";
+      }
       console.log("Form submitted:", jsonBody !== undefined ? jsonBody : {});
     } catch (err) {
       var msg = err && err.message ? err.message : "Submission failed";
-      var statusEl = document.getElementById("form-status");
-      if (statusEl) statusEl.textContent = msg;
+      var statusErr = document.getElementById("form-status");
+      if (statusErr) {
+        statusErr.textContent = msg;
+        statusErr.className = "alert alert-danger mb-3";
+      }
     }
     /* FORMSYNC_API_SUBMIT_END */`;
 }

--- a/formsync/services/formgen-service/src/generators/react-generator.ts
+++ b/formsync/services/formgen-service/src/generators/react-generator.ts
@@ -490,6 +490,7 @@ function generateFieldComponent(
   domIdByKey: Map<string, string>,
   ctx: RepeaterCodegenCtx | undefined,
   repeaterStates: RepeaterStateSpec[],
+  asTableCell = false,
 ): string {
   const { type, label, required, ui } = field;
   const domBase = domIdByKey.get(field.key) ?? field.id;
@@ -518,9 +519,62 @@ function generateFieldComponent(
     const setterName = `set${spec.stateVar.charAt(0).toUpperCase()}${spec.stateVar.slice(1)}`;
     const innerRows = children
       .map((child: FieldModel) =>
-        generateFieldComponent(child, domIdByKey, { repeaterRoot: field.key }, repeaterStates),
+        generateFieldComponent(child, domIdByKey, { repeaterRoot: field.key }, repeaterStates, false),
       )
       .join("\n\n");
+
+    const displayMode =
+      field.ui && typeof field.ui === "object" && (field.ui as Record<string, unknown>)["displayMode"] === "table"
+        ? "table"
+        : "cards";
+
+    if (displayMode === "table" && children.length > 0) {
+      const thCells = children
+        .map(
+          (c: FieldModel) =>
+            `<th scope="col" className="align-middle">${escapeHtml(c.label)}${
+              c.required ? ' <span className="text-danger" aria-hidden="true">*</span>' : ""
+            }</th>`,
+        )
+        .join("");
+      const tdCells = children
+        .map(
+          (child: FieldModel) =>
+            `<td className="align-middle repeater-table-cell" style={{ minWidth: "8rem", verticalAlign: "middle" }}>${generateFieldComponent(
+              child,
+              domIdByKey,
+              { repeaterRoot: field.key },
+              repeaterStates,
+              true,
+            )}</td>`,
+        )
+        .join("");
+
+      return `<fieldset className="field-group repeater-field repeater-table mb-4" style={{ border: '1px solid #e5e7eb', borderRadius: '4px', padding: '1rem' }}>
+        <legend className="field-legend" style={{ padding: '0 0.5rem', fontWeight: 600 }}>${escapeHtml(label)}${required ? ' <span className="required" aria-hidden="true">*</span>' : ""}</legend>
+        <div style={{ overflowX: "auto" }}>
+        <table className="repeater-data-table" style={{ borderCollapse: "collapse", width: "100%", fontSize: "0.95rem" }}>
+          <thead>
+            <tr>
+              ${thCells}
+              <th scope="col" className="text-end repeater-table-actions" style={{ width: "6rem" }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {${spec.stateVar}.map((rowId, rowIdx) => (
+              <tr key={rowId} className="repeater-row">
+                ${tdCells}
+                <td className="text-end align-middle">
+                  <button type="button" className="btn btn-sm btn-outline-danger" onClick={() => ${setterName}((rows) => rows.length <= 1 ? rows : rows.filter((_, i) => i !== rowIdx))}>Remove</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        </div>
+        <button type="button" className="btn btn-sm btn-outline-primary mt-2" onClick={() => ${setterName}((rows) => [...rows, String(Date.now())])}>Add row</button>
+      </fieldset>`;
+    }
 
     return `<fieldset className="field-group repeater-field mb-4" style={{ border: '1px solid #e5e7eb', borderRadius: '4px', padding: '1rem' }}>
         <legend className="field-legend" style={{ padding: '0 0.5rem', fontWeight: 600 }}>${escapeHtml(label)}${required ? ' <span className="required" aria-hidden="true">*</span>' : ""}</legend>
@@ -601,7 +655,7 @@ function generateFieldComponent(
             ${ariaDescribedBy}
             ${autoCompleteAttr}
           ></textarea>`;
-      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan, { tableCell: !!asTableCell });
     }
     case "select": {
       const options = field.constraints?.enum || [];
@@ -619,7 +673,7 @@ function generateFieldComponent(
             <option value="">${escapeHtml(placeholder) || "Select..."}</option>
             ${options.map((o: string) => `<option value="${escapeHtml(o)}">${escapeHtml(o)}</option>`).join("\n            ")}
           </select>`;
-      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan, { tableCell: !!asTableCell });
     }
     case "checkbox": {
       const input = `<input
@@ -640,9 +694,11 @@ function generateFieldComponent(
       const cbHelp = helpText
         ? `<small ${cbHelpId} className="field-help-text" style={{ marginLeft: 'auto' }}>${escapeHtml(helpText)}</small>`
         : "";
-      return `<div className="field-item checkbox-item" ${buildStyle(rowStyle)}>
+      const labelCls = asTableCell ? "field-label sr-only" : "field-label";
+      const itemCls = asTableCell ? "field-item checkbox-item mb-0" : "field-item checkbox-item";
+      return `<div className="${itemCls}" ${buildStyle(rowStyle)}>
           ${input}
-          <label ${htmlForAttr} className="field-label" style={{ marginBottom: 0 }}>
+          <label ${htmlForAttr} className="${labelCls}" style={{ marginBottom: 0 }}>
             ${escapeHtml(label)}${required ? '<span className="required" aria-hidden="true">*</span>' : ""}
           </label>
           ${cbHelp}
@@ -666,7 +722,7 @@ function generateFieldComponent(
             ${ariaErrMsg}
             ${ariaDescribedBy}
           />`;
-      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan, { tableCell: !!asTableCell });
     }
     case "signature": {
       const hidId = `${domBase}_sig`;
@@ -711,7 +767,7 @@ function generateFieldComponent(
             }}
           />
           <input type="hidden" ${nameAttr} id=${hidIdExpr} />`;
-      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan, { tableCell: !!asTableCell });
     }
     case "typeahead": {
       const url = ui?.["x-ui"]?.asyncSource?.url ?? "";
@@ -734,7 +790,7 @@ function generateFieldComponent(
             ${ariaDescribedBy}
           />
           <datalist id=${dlIdExpr}></datalist>`;
-      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan, { tableCell: !!asTableCell });
     }
     case "calculated": {
       const formula = field["x-calc"] ?? "";
@@ -749,7 +805,7 @@ function generateFieldComponent(
             ${ariaErrMsg}
             ${ariaDescribedBy}
           />`;
-      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan, { tableCell: !!asTableCell });
     }
     case "number": {
       const c = field.constraints;
@@ -771,7 +827,7 @@ function generateFieldComponent(
             ${ariaErrMsg}
             ${ariaDescribedBy}
           />`;
-      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan, { tableCell: !!asTableCell });
     }
     case "text":
     case "email":
@@ -790,7 +846,7 @@ function generateFieldComponent(
             ${ariaDescribedBy}
             ${autoCompleteAttr}
           />`;
-      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan, { tableCell: !!asTableCell });
     }
     case "unknown":
     default: {
@@ -806,7 +862,7 @@ function generateFieldComponent(
             ${ariaErrMsg}
             ${ariaDescribedBy}
           />`;
-      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan, { tableCell: !!asTableCell });
     }
   }
 }
@@ -819,9 +875,13 @@ function wrapField(
   buildStyle: (e?: string[]) => string,
   helpSpan: string,
   errSpan: string,
+  opts?: { tableCell?: boolean },
 ): string {
-  return `<div className="field-item" ${buildStyle()}>
-          <label ${htmlForAttr} className="field-label">
+  const tc = opts?.tableCell;
+  const labelClass = tc ? "field-label sr-only" : "field-label";
+  const itemClass = tc ? "field-item mb-0" : "field-item";
+  return `<div className="${itemClass}" ${buildStyle()}>
+          <label ${htmlForAttr} className="${labelClass}">
             ${escapeHtml(label)}${required ? '<span className="required" aria-hidden="true">*</span>' : ""}
           </label>
           ${input}

--- a/formsync/services/formgen-service/src/generators/react-generator.ts
+++ b/formsync/services/formgen-service/src/generators/react-generator.ts
@@ -30,6 +30,33 @@ function escapeJsSingleQuotedString(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
 }
 
+/** Repeater chrome from field.ui.styleOverrides (matches builder preview + static HTML). */
+function repeaterChromeStyles(field: FieldModel): {
+  fieldsetStyle: string;
+  legendStyle: string;
+  theadTrStyle: string;
+  addButtonStyle: string;
+} {
+  const o = field.ui?.styleOverrides as Record<string, string> | undefined;
+  const border = o?.borderColor ?? "#e5e7eb";
+  const bg = o?.backgroundColor;
+  const lc = o?.labelColor;
+  const accent = o?.focusColor;
+  const fs: string[] = [`border: '1px solid ${border}'`, `borderRadius: '4px'`, `padding: '1rem'`];
+  if (bg) fs.push(`background: '${bg}'`);
+  const fieldsetStyle = fs.join(", ");
+  const legendParts = [`padding: '0 0.5rem'`, `fontWeight: 600`];
+  if (lc) legendParts.push(`color: '${lc}'`);
+  const legendStyle = legendParts.join(", ");
+  const theadBg =
+    lc && bg ? `color-mix(in srgb, ${lc} 12%, ${bg})` : bg ? `color-mix(in srgb, #64748b 8%, ${bg})` : "#f1f5f9";
+  const theadTrParts = [`background: '${theadBg}'`];
+  if (lc) theadTrParts.push(`color: '${lc}'`);
+  const theadTrStyle = theadTrParts.join(", ");
+  const addButtonStyle = accent ? `color: '${accent}', borderColor: '${accent}'` : "";
+  return { fieldsetStyle, legendStyle, theadTrStyle, addButtonStyle };
+}
+
 /** Rules for generated client-side validate() — keyed by semantic field key (matches indexed form names via template path). */
 function buildClientFieldRulesJson(formModel: FormModel): string {
   type Rule = {
@@ -339,6 +366,31 @@ function formValuesForCalc(form: HTMLFormElement | null): Record<string, string>
   return out;
 }
 
+function scopedRepeaterValuesForCalc(
+  form: HTMLFormElement | null,
+  repeaterRoot: string,
+  rowIdx: number,
+): Record<string, string> {
+  const flat = formValuesForCalc(form);
+  const prefix = repeaterRoot + "." + rowIdx + ".";
+  const out: Record<string, string> = { ...flat };
+  for (const [k, v] of Object.entries(flat)) {
+    if (k.startsWith(prefix)) {
+      out[k.slice(prefix.length)] = v;
+    }
+  }
+  return out;
+}
+
+function syncRichTextEditors(form: HTMLFormElement | null) {
+  if (!form) return;
+  form.querySelectorAll<HTMLInputElement>('input[type="hidden"][data-fs-richtext]').forEach((hid) => {
+    const wrap = hid.closest(".richtext-wrap");
+    const ed = wrap?.querySelector<HTMLElement>(".richtext-editable");
+    if (ed) hid.value = ed.innerHTML;
+  });
+}
+
 function syncSignaturePads(form: HTMLFormElement | null) {
   if (!form) return;
   form.querySelectorAll<HTMLCanvasElement>('canvas[data-fs-sig-target]').forEach((canvas) => {
@@ -416,6 +468,7 @@ ${repeaterStateDeclarations ? `\n${repeaterStateDeclarations}\n` : ""}
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    syncRichTextEditors(e.currentTarget);
     syncSignaturePads(e.currentTarget);
     const errs = validateForm(e.currentTarget, FIELD_RULES);
     setErrors(errs);
@@ -516,6 +569,19 @@ function generateFieldComponent(
           <p className="text-muted small">Nested repeaters are not supported in this export.</p>
         </div>`;
     }
+    if (children.length === 0) {
+      const emptyRc = repeaterChromeStyles(field);
+      const emptyAdd = emptyRc.addButtonStyle
+        ? `<button type="button" className="btn btn-sm btn-outline-primary" style={{ ${emptyRc.addButtonStyle} }} onClick={() => {}} disabled title="Add child fields in the builder first">Add row</button>`
+        : `<button type="button" className="btn btn-sm btn-outline-primary" disabled title="Add child fields in the builder first">Add row</button>`;
+      return `<fieldset className="field-group repeater-field mb-4" style={{ ${emptyRc.fieldsetStyle} }}>
+        <legend className="field-legend" style={{ ${emptyRc.legendStyle} }}>${escapeHtml(label)}${required ? ' <span className="required" aria-hidden="true">*</span>' : ""}</legend>
+        <p className="text-muted small mb-3" role="note">
+          This repeater has no column fields yet. In FormSync, select the repeater → add fields inside it (each becomes a table column or card row). Then re-export.
+        </p>
+        ${emptyAdd}
+      </fieldset>`;
+    }
     const setterName = `set${spec.stateVar.charAt(0).toUpperCase()}${spec.stateVar.slice(1)}`;
     const innerRows = children
       .map((child: FieldModel) =>
@@ -529,6 +595,10 @@ function generateFieldComponent(
         : "cards";
 
     if (displayMode === "table" && children.length > 0) {
+      const rc = repeaterChromeStyles(field);
+      const addTableBtn = rc.addButtonStyle
+        ? `<button type="button" className="btn btn-sm btn-outline-primary mt-2" style={{ ${rc.addButtonStyle} }} onClick={() => ${setterName}((rows) => [...rows, String(Date.now())])}>Add row</button>`
+        : `<button type="button" className="btn btn-sm btn-outline-primary mt-2" onClick={() => ${setterName}((rows) => [...rows, String(Date.now())])}>Add row</button>`;
       const thCells = children
         .map(
           (c: FieldModel) =>
@@ -550,12 +620,12 @@ function generateFieldComponent(
         )
         .join("");
 
-      return `<fieldset className="field-group repeater-field repeater-table mb-4" style={{ border: '1px solid #e5e7eb', borderRadius: '4px', padding: '1rem' }}>
-        <legend className="field-legend" style={{ padding: '0 0.5rem', fontWeight: 600 }}>${escapeHtml(label)}${required ? ' <span className="required" aria-hidden="true">*</span>' : ""}</legend>
+      return `<fieldset className="field-group repeater-field repeater-table mb-4" style={{ ${rc.fieldsetStyle} }}>
+        <legend className="field-legend" style={{ ${rc.legendStyle} }}>${escapeHtml(label)}${required ? ' <span className="required" aria-hidden="true">*</span>' : ""}</legend>
         <div style={{ overflowX: "auto" }}>
         <table className="repeater-data-table" style={{ borderCollapse: "collapse", width: "100%", fontSize: "0.95rem" }}>
           <thead>
-            <tr style={{ background: "#f1f5f9" }}>
+            <tr style={{ ${rc.theadTrStyle} }}>
               ${thCells}
               <th scope="col" className="text-end repeater-table-actions" style={{ width: "6rem" }}>Actions</th>
             </tr>
@@ -572,19 +642,24 @@ function generateFieldComponent(
           </tbody>
         </table>
         </div>
-        <button type="button" className="btn btn-sm btn-outline-primary mt-2" onClick={() => ${setterName}((rows) => [...rows, String(Date.now())])}>Add row</button>
+        ${addTableBtn}
       </fieldset>`;
     }
 
-    return `<fieldset className="field-group repeater-field mb-4" style={{ border: '1px solid #e5e7eb', borderRadius: '4px', padding: '1rem' }}>
-        <legend className="field-legend" style={{ padding: '0 0.5rem', fontWeight: 600 }}>${escapeHtml(label)}${required ? ' <span className="required" aria-hidden="true">*</span>' : ""}</legend>
+    const rcCards = repeaterChromeStyles(field);
+    const addCardBtn = rcCards.addButtonStyle
+      ? `<button type="button" className="btn btn-sm btn-outline-primary" style={{ ${rcCards.addButtonStyle} }} onClick={() => ${setterName}((rows) => [...rows, String(Date.now())])}>Add row</button>`
+      : `<button type="button" className="btn btn-sm btn-outline-primary" onClick={() => ${setterName}((rows) => [...rows, String(Date.now())])}>Add row</button>`;
+
+    return `<fieldset className="field-group repeater-field mb-4" style={{ ${rcCards.fieldsetStyle} }}>
+        <legend className="field-legend" style={{ ${rcCards.legendStyle} }}>${escapeHtml(label)}${required ? ' <span className="required" aria-hidden="true">*</span>' : ""}</legend>
         {${spec.stateVar}.map((rowId, rowIdx) => (
         <div key={rowId} className="repeater-row border rounded p-3 mb-3 bg-light">
           ${innerRows}
           <button type="button" className="btn btn-sm btn-outline-danger mt-2" onClick={() => ${setterName}((rows) => rows.length <= 1 ? rows : rows.filter((_, i) => i !== rowIdx))}>Remove row</button>
         </div>
         ))}
-        <button type="button" className="btn btn-sm btn-outline-primary" onClick={() => ${setterName}((rows) => [...rows, String(Date.now())])}>Add row</button>
+        ${addCardBtn}
       </fieldset>`;
   }
 
@@ -641,8 +716,7 @@ function generateFieldComponent(
     : `<span id="${domBase}-error" className="field-error" role="alert" aria-live="polite">{${errExpr}}</span>`;
 
   switch (type) {
-    case "textarea":
-    case "richtext": {
+    case "textarea": {
       const input = `<textarea
             ${nameAttr}
             ${idAttr}
@@ -656,6 +730,35 @@ function generateFieldComponent(
             ${autoCompleteAttr}
           ></textarea>`;
       return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan, { tableCell: !!asTableCell });
+    }
+    case "richtext": {
+      const richInput = `<div className="richtext-wrap">
+            <div className="richtext-toolbar" role="toolbar" aria-label="Formatting">
+              <button type="button" className="richtext-tool" onClick={(e) => { const ed = e.currentTarget.closest('.richtext-wrap')?.querySelector<HTMLElement>('.richtext-editable'); ed?.focus(); document.execCommand('bold'); }} title="Bold"><strong>B</strong></button>
+              <button type="button" className="richtext-tool" onClick={(e) => { const ed = e.currentTarget.closest('.richtext-wrap')?.querySelector<HTMLElement>('.richtext-editable'); ed?.focus(); document.execCommand('italic'); }} title="Italic"><em>I</em></button>
+              <button type="button" className="richtext-tool" onClick={(e) => { const ed = e.currentTarget.closest('.richtext-wrap')?.querySelector<HTMLElement>('.richtext-editable'); ed?.focus(); document.execCommand('underline'); }} title="Underline"><span style={{ textDecoration: 'underline' }}>U</span></button>
+              <button type="button" className="richtext-tool" onClick={(e) => { const ed = e.currentTarget.closest('.richtext-wrap')?.querySelector<HTMLElement>('.richtext-editable'); ed?.focus(); document.execCommand('insertUnorderedList'); }} title="Bullets">•</button>
+              <button type="button" className="richtext-tool" onClick={(e) => { const ed = e.currentTarget.closest('.richtext-wrap')?.querySelector<HTMLElement>('.richtext-editable'); ed?.focus(); document.execCommand('insertOrderedList'); }} title="Numbered list">1.</button>
+            </div>
+            <div
+              ${idAttr}
+              className="field-input richtext-editable"
+              contentEditable
+              suppressContentEditableWarning
+              ${placeholder ? `data-placeholder="${escapeHtml(placeholder)}"` : ""}
+              ${ariaRequired}
+              ${ariaInvalid}
+              ${ariaErrMsg}
+              ${ariaDescribedBy}
+              onInput={(e) => {
+                const wrap = e.currentTarget.closest('.richtext-wrap');
+                const hid = wrap?.querySelector<HTMLInputElement>('input[data-fs-richtext]');
+                if (hid) hid.value = e.currentTarget.innerHTML;
+              }}
+            />
+            <input type="hidden" data-fs-richtext ${nameAttr} />
+          </div>`;
+      return wrapField(label, required, htmlForAttr, richInput, buildStyle, helpSpan, errSpan, { tableCell: !!asTableCell });
     }
     case "select": {
       const options = field.constraints?.enum || [];
@@ -739,7 +842,7 @@ function generateFieldComponent(
             id=${canvasIdExpr}
             width={400}
             height={160}
-            className="border rounded bg-white"
+            className="field-input signature-pad-canvas"
             ${sigTargetAttr}
             style={{ maxWidth: '100%', touchAction: 'none' }}
             onPointerDown={(e) => {
@@ -794,12 +897,15 @@ function generateFieldComponent(
     }
     case "calculated": {
       const formula = field["x-calc"] ?? "";
+      const calcValuesExpr = ctx
+        ? `scopedRepeaterValuesForCalc(formRef.current, '${escapeJsSingleQuotedString(ctx.repeaterRoot)}', rowIdx)`
+        : `formValuesForCalc(formRef.current)`;
       const input = `<input
             readOnly
             ${nameAttr}
             ${idAttr}
             className="field-input"
-            value={String(evaluateCalcExpression(${JSON.stringify(formula)}, formValuesForCalc(formRef.current)))}
+            value={String(evaluateCalcExpression(${JSON.stringify(formula)}, ${calcValuesExpr}))}
             ${ariaRequired}
             ${ariaInvalid}
             ${ariaErrMsg}

--- a/formsync/services/formgen-service/src/generators/react-generator.ts
+++ b/formsync/services/formgen-service/src/generators/react-generator.ts
@@ -545,6 +545,7 @@ function syncSignaturePads(form: HTMLFormElement | null) {
     setErrors(stepErrs);
     const errorKeys = Object.keys(stepErrs);
     if (errorKeys.length > 0) {
+      setSuccessModalOpen(false);
       const firstKey = errorKeys[0];
       const firstDetail = firstKey ? stepErrs[firstKey] : "";
       setStatusKind("error");
@@ -603,6 +604,8 @@ function App() {
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [statusMessage, setStatusMessage] = useState<string>('');
   const [statusKind, setStatusKind] = useState<'error' | 'success'>('error');
+  const [successModalOpen, setSuccessModalOpen] = useState(false);
+  const [successModalMessage, setSuccessModalMessage] = useState('');
 ${wizardStepStateLine}${repeaterStateDeclarations ? `\n${repeaterStateDeclarations}\n` : ""}
 
   useEffect(() => {
@@ -659,6 +662,7 @@ ${wizardFocusEffect}${handleWizardNextBlock}
     const errorKeys = Object.keys(errs);
     const errorCount = errorKeys.length;
     if (errorCount > 0) {
+      setSuccessModalOpen(false);
       const firstKey = errorKeys[0];
       const firstDetail = firstKey ? errs[firstKey] : "";
       setStatusKind("error");
@@ -695,26 +699,59 @@ ${wizardFocusEffect}${handleWizardNextBlock}
     const formData = new FormData(e.currentTarget);
     const data = Object.fromEntries(formData.entries());
     /* FORMSYNC_API_SUBMIT_START */
-    setStatusKind("success");
-    setStatusMessage("Submitted successfully. Thanks — your response was recorded.");
+    setSuccessModalMessage("Thanks — your response was recorded.");
+    setSuccessModalOpen(true);
     console.log('Form submitted:', data);
     /* FORMSYNC_API_SUBMIT_END */
   };
 
   return (
     <div className="form-container">
-      {statusMessage ? (
+      {statusKind === "error" && statusMessage ? (
         <div
-          className={
-            statusKind === "success"
-              ? "form-validation-summary form-submit-success"
-              : "form-validation-summary"
-          }
+          className="form-validation-summary"
           role="alert"
           aria-live="polite"
           aria-atomic="true"
         >
           {statusMessage}
+        </div>
+      ) : null}
+      {successModalOpen ? (
+        <div
+          className="fs-success-modal-backdrop"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="fs-success-title"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) {
+              setSuccessModalOpen(false);
+              setSuccessModalMessage("");
+            }
+          }}
+        >
+          <div className="fs-success-modal" onClick={(e) => e.stopPropagation()}>
+            <div className="fs-success-modal-icon-wrap" aria-hidden="true">
+              <svg className="fs-success-modal-icon" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" />
+                <path d="M8 12l2.5 2.5L16 9" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </div>
+            <h2 id="fs-success-title" className="fs-success-modal-title">
+              Success
+            </h2>
+            <p className="fs-success-modal-text">{successModalMessage}</p>
+            <button
+              type="button"
+              className="fs-success-modal-btn"
+              onClick={() => {
+                setSuccessModalOpen(false);
+                setSuccessModalMessage("");
+              }}
+            >
+              OK
+            </button>
+          </div>
         </div>
       ) : null}
       <h1 className="form-title">${escapeHtml(title)}</h1>

--- a/formsync/services/formgen-service/src/generators/react-generator.ts
+++ b/formsync/services/formgen-service/src/generators/react-generator.ts
@@ -136,6 +136,13 @@ function templatePathFromIndexedPath(path: string): string {
   return path.split(".").filter((p) => !/^\\d+$/.test(p)).join(".");
 }
 
+function resolveRuleFromKeys(rules: Record<string, FieldRule>, tk: string): FieldRule | undefined {
+  let rule = rules[tk];
+  if (rule) return rule;
+  const parts = tk.split(".").filter(Boolean);
+  return parts.length ? rules[parts[parts.length - 1]] : undefined;
+}
+
 function collectNamedFieldErrors(root: Element, rules: Record<string, FieldRule>): Record<string, string> {
   const errs: Record<string, string> = {};
   const emailRe = /^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/;
@@ -200,7 +207,7 @@ function collectNamedFieldErrors(root: Element, rules: Record<string, FieldRule>
     const nm = (el as HTMLInputElement).name;
     if (!nm) return;
     const tk = templatePathFromIndexedPath(nm);
-    const rule = rules[tk];
+    const rule = resolveRuleFromKeys(rules, tk);
     if (!rule) return;
 
     const tag = el.tagName.toLowerCase();

--- a/formsync/services/formgen-service/src/generators/react-generator.ts
+++ b/formsync/services/formgen-service/src/generators/react-generator.ts
@@ -419,6 +419,7 @@ function App() {
   const [, setFormTick] = useState(0);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [statusMessage, setStatusMessage] = useState<string>('');
+  const [statusKind, setStatusKind] = useState<'error' | 'success'>('error');
 ${repeaterStateDeclarations ? `\n${repeaterStateDeclarations}\n` : ""}
 
   useEffect(() => {
@@ -477,6 +478,7 @@ ${repeaterStateDeclarations ? `\n${repeaterStateDeclarations}\n` : ""}
     if (errorCount > 0) {
       const firstKey = errorKeys[0];
       const firstDetail = firstKey ? errs[firstKey] : "";
+      setStatusKind("error");
       setStatusMessage(
         errorCount === 1
           ? firstDetail || "Please fix the highlighted field."
@@ -510,7 +512,8 @@ ${repeaterStateDeclarations ? `\n${repeaterStateDeclarations}\n` : ""}
     const formData = new FormData(e.currentTarget);
     const data = Object.fromEntries(formData.entries());
     /* FORMSYNC_API_SUBMIT_START */
-    setStatusMessage('');
+    setStatusKind("success");
+    setStatusMessage("Submitted successfully. Thanks — your response was recorded.");
     console.log('Form submitted:', data);
     /* FORMSYNC_API_SUBMIT_END */
   };
@@ -518,7 +521,16 @@ ${repeaterStateDeclarations ? `\n${repeaterStateDeclarations}\n` : ""}
   return (
     <div className="form-container">
       {statusMessage ? (
-        <div className="form-validation-summary" role="alert" aria-live="polite" aria-atomic="true">
+        <div
+          className={
+            statusKind === "success"
+              ? "form-validation-summary form-submit-success"
+              : "form-validation-summary"
+          }
+          role="alert"
+          aria-live="polite"
+          aria-atomic="true"
+        >
           {statusMessage}
         </div>
       ) : null}

--- a/formsync/services/formgen-service/src/generators/react-generator.ts
+++ b/formsync/services/formgen-service/src/generators/react-generator.ts
@@ -30,6 +30,166 @@ function escapeJsSingleQuotedString(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
 }
 
+/** Rules for generated client-side validate() — keyed by semantic field key (matches indexed form names via template path). */
+function buildClientFieldRulesJson(formModel: FormModel): string {
+  type Rule = {
+    label: string;
+    type: string;
+    required: boolean;
+    min?: number;
+    max?: number;
+    minLength?: number;
+    maxLength?: number;
+    pattern?: string;
+  };
+  const rules: Record<string, Rule> = {};
+  const walk = (fields: FieldModel[]) => {
+    for (const f of fields) {
+      if (f.type === "group" || f.type === "repeater") {
+        if (f.children?.length) walk(f.children);
+      } else {
+        const r: Rule = {
+          label: f.label,
+          type: f.type,
+          required: f.required,
+        };
+        const c = f.constraints;
+        if (c?.min !== undefined) r.min = c.min;
+        if (c?.max !== undefined) r.max = c.max;
+        if (c?.minLength !== undefined) r.minLength = c.minLength;
+        if (c?.maxLength !== undefined) r.maxLength = c.maxLength;
+        if (c?.pattern !== undefined) r.pattern = c.pattern;
+        rules[f.key] = r;
+      }
+    }
+  };
+  walk(formModel.fields);
+  return JSON.stringify(rules);
+}
+
+/** Source appended to App.tsx: FIELD_RULES + validate helpers (strict TS). */
+function buildGeneratedClientValidationSource(): string {
+  return `type FieldRule = {
+  label: string;
+  type: string;
+  required: boolean;
+  min?: number;
+  max?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+};
+
+function templatePathFromIndexedPath(path: string): string {
+  return path.split(".").filter((p) => !/^\\d+$/.test(p)).join(".");
+}
+
+function validateForm(form: HTMLFormElement, rules: Record<string, FieldRule>): Record<string, string> {
+  const errs: Record<string, string> = {};
+  const emailRe = /^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/;
+
+  const applyTextRules = (rule: FieldRule, raw: string, path: string): void => {
+    const v = raw.trim();
+    if (rule.required && v === "") {
+      errs[path] = rule.label + " is required.";
+      return;
+    }
+    if (v === "") return;
+
+    if (rule.type === "number") {
+      const normalized = v.replace(/\\s/g, "");
+      if (/[eE]/.test(normalized)) {
+        errs[path] = rule.label + " must be a valid number.";
+        return;
+      }
+      if (!/^-?(?:\\d+\\.?\\d*|\\.\\d+)$/.test(normalized)) {
+        errs[path] = rule.label + " must be a valid number.";
+        return;
+      }
+      const num = Number(normalized);
+      if (Number.isNaN(num)) {
+        errs[path] = rule.label + " must be a valid number.";
+        return;
+      }
+      const disallowNegative = rule.min !== undefined && rule.min >= 0;
+      if (disallowNegative && num < 0) {
+        errs[path] = rule.label + " cannot be negative.";
+        return;
+      }
+      if (rule.min !== undefined && num < rule.min) {
+        errs[path] = rule.label + " must be at least " + rule.min + ".";
+        return;
+      }
+      if (rule.max !== undefined && num > rule.max) {
+        errs[path] = rule.label + " must be at most " + rule.max + ".";
+        return;
+      }
+    } else if (rule.type === "email") {
+      if (!emailRe.test(v)) errs[path] = "Enter a valid email address.";
+    }
+
+    if (!errs[path] && rule.minLength !== undefined && v.length < rule.minLength) {
+      errs[path] = rule.label + " is too short.";
+    }
+    if (!errs[path] && rule.maxLength !== undefined && v.length > rule.maxLength) {
+      errs[path] = rule.label + " is too long.";
+    }
+    if (!errs[path] && rule.pattern) {
+      try {
+        const re = new RegExp(rule.pattern);
+        if (!re.test(v)) errs[path] = rule.label + " format is invalid.";
+      } catch {
+        /* ignore bad pattern */
+      }
+    }
+  };
+
+  form.querySelectorAll<HTMLElement>("[name]").forEach((el) => {
+    const nm = (el as HTMLInputElement).name;
+    if (!nm) return;
+    const tk = templatePathFromIndexedPath(nm);
+    const rule = rules[tk];
+    if (!rule) return;
+
+    const tag = el.tagName.toLowerCase();
+
+    if (tag === "input") {
+      const inp = el as HTMLInputElement;
+      const ty = inp.type;
+      if (ty === "checkbox") {
+        if (rule.required && !inp.checked) errs[nm] = rule.label + " is required.";
+        return;
+      }
+      if (ty === "file") {
+        if (rule.required && (!inp.files || inp.files.length === 0)) errs[nm] = rule.label + " is required.";
+        return;
+      }
+      if (ty === "hidden") {
+        if (rule.required && !(inp.value || "").trim()) errs[nm] = rule.label + " is required.";
+        return;
+      }
+      if (inp.readOnly && rule.type === "calculated") return;
+      applyTextRules(rule, inp.value ?? "", nm);
+      return;
+    }
+
+    if (tag === "select") {
+      const sel = el as HTMLSelectElement;
+      const val = sel.value;
+      if (rule.required && (val === "" || val == null)) errs[nm] = rule.label + " is required.";
+      return;
+    }
+
+    if (tag === "textarea") {
+      applyTextRules(rule, (el as HTMLTextAreaElement).value ?? "", nm);
+    }
+  });
+
+  return errs;
+}
+`;
+}
+
 function sanitizeIdent(s: string): string {
   return s.replace(/[^a-zA-Z0-9]/g, "_");
 }
@@ -190,12 +350,17 @@ function syncSignaturePads(form: HTMLFormElement | null) {
 }
 `;
 
+  const fieldRulesJson = buildClientFieldRulesJson(formModel);
+
   return `import React, { FormEvent, useState, useRef, useEffect } from 'react';
 
 ${calcHelpers}
+${buildGeneratedClientValidationSource()}
 const FIELD_ID_MAP: Record<string, string> = {
 ${fieldIdMapEntries}
 };
+
+const FIELD_RULES = ${fieldRulesJson} as Record<string, FieldRule>;
 
 function App() {
   const formRef = useRef<HTMLFormElement>(null);
@@ -249,17 +414,10 @@ ${repeaterStateDeclarations ? `\n${repeaterStateDeclarations}\n` : ""}
     return () => cleanups.forEach((c) => c());
   }, []);
 
-  const validate = (data: Record<string, FormDataEntryValue>): Record<string, string> => {
-    const errs: Record<string, string> = {};
-    return errs;
-  };
-
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     syncSignaturePads(e.currentTarget);
-    const formData = new FormData(e.currentTarget);
-    const data = Object.fromEntries(formData.entries());
-    const errs = validate(data);
+    const errs = validateForm(e.currentTarget, FIELD_RULES);
     setErrors(errs);
     const errorCount = Object.keys(errs).length;
     if (errorCount > 0) {
@@ -268,15 +426,31 @@ ${repeaterStateDeclarations ? `\n${repeaterStateDeclarations}\n` : ""}
           ? '1 error found. Please review the highlighted field.'
           : errorCount + ' errors found. Please review the highlighted fields.'
       );
-      const firstErrorKey = Object.keys(errs)[0];
-      const firstErrorId = FIELD_ID_MAP[firstErrorKey];
-      if (firstErrorId) {
-        const el = document.getElementById(firstErrorId) as HTMLElement | null;
+      const firstKey = Object.keys(errs)[0];
+      if (firstKey) {
+        let focusEl: HTMLElement | null = null;
+        const els = e.currentTarget.elements;
+        for (let i = 0; i < els.length; i++) {
+          const fe = els[i];
+          if (
+            fe instanceof HTMLElement &&
+            "name" in fe &&
+            (fe as HTMLInputElement).name === firstKey
+          ) {
+            focusEl = fe;
+            break;
+          }
+        }
+        const tk = templatePathFromIndexedPath(firstKey);
+        const fallbackId = FIELD_ID_MAP[tk];
+        const el = focusEl ?? (fallbackId ? (document.getElementById(fallbackId) as HTMLElement | null) : null);
         el?.focus();
-        el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        el?.scrollIntoView({ behavior: "smooth", block: "center" });
       }
       return;
     }
+    const formData = new FormData(e.currentTarget);
+    const data = Object.fromEntries(formData.entries());
     /* FORMSYNC_API_SUBMIT_START */
     setStatusMessage('');
     console.log('Form submitted:', data);
@@ -570,10 +744,31 @@ function generateFieldComponent(
           />`;
       return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
     }
+    case "number": {
+      const c = field.constraints;
+      const minAttr = c?.min !== undefined ? `min={${c.min}}` : "";
+      const maxAttr = c?.max !== undefined ? `max={${c.max}}` : "";
+      const input = `<input
+            type="number"
+            ${nameAttr}
+            ${idAttr}
+            className="field-input"
+            inputMode="decimal"
+            ${minAttr}
+            ${maxAttr}
+            step="any"
+            ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ""}
+            ${required ? "required" : ""}
+            ${ariaRequired}
+            ${ariaInvalid}
+            ${ariaErrMsg}
+            ${ariaDescribedBy}
+          />`;
+      return wrapField(label, required, htmlForAttr, input, buildStyle, helpSpan, errSpan);
+    }
     case "text":
     case "email":
     case "password":
-    case "number":
     case "date": {
       const input = `<input
             type="${type}"

--- a/formsync/services/formgen-service/src/generators/react-generator.ts
+++ b/formsync/services/formgen-service/src/generators/react-generator.ts
@@ -555,7 +555,7 @@ function generateFieldComponent(
         <div style={{ overflowX: "auto" }}>
         <table className="repeater-data-table" style={{ borderCollapse: "collapse", width: "100%", fontSize: "0.95rem" }}>
           <thead>
-            <tr>
+            <tr style={{ background: "#f1f5f9" }}>
               ${thCells}
               <th scope="col" className="text-end repeater-table-actions" style={{ width: "6rem" }}>Actions</th>
             </tr>

--- a/formsync/services/formgen-service/src/generators/react-generator.ts
+++ b/formsync/services/formgen-service/src/generators/react-generator.ts
@@ -30,6 +30,31 @@ function escapeJsSingleQuotedString(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
 }
 
+/** Wizard step slice: nested group/repeater children honor stepIndex ?? 0. */
+function pruneFieldsForWizardStep(fields: FieldModel[], stepIdx: number): FieldModel[] {
+  const out: FieldModel[] = [];
+  for (const f of fields) {
+    if (f.type === "group" && f.children?.length) {
+      const children = pruneFieldsForWizardStep(f.children, stepIdx);
+      if (children.length > 0) {
+        out.push({ ...f, children });
+      }
+      continue;
+    }
+    if (f.type === "repeater" && f.children?.length) {
+      const children = pruneFieldsForWizardStep(f.children, stepIdx);
+      if (children.length > 0) {
+        out.push({ ...f, children });
+      }
+      continue;
+    }
+    if ((f.stepIndex ?? 0) === stepIdx) {
+      out.push(f);
+    }
+  }
+  return out;
+}
+
 /** Repeater chrome from field.ui.styleOverrides (matches builder preview + static HTML). */
 function repeaterChromeStyles(field: FieldModel): {
   fieldsetStyle: string;
@@ -111,7 +136,7 @@ function templatePathFromIndexedPath(path: string): string {
   return path.split(".").filter((p) => !/^\\d+$/.test(p)).join(".");
 }
 
-function validateForm(form: HTMLFormElement, rules: Record<string, FieldRule>): Record<string, string> {
+function collectNamedFieldErrors(root: Element, rules: Record<string, FieldRule>): Record<string, string> {
   const errs: Record<string, string> = {};
   const emailRe = /^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/;
 
@@ -171,7 +196,7 @@ function validateForm(form: HTMLFormElement, rules: Record<string, FieldRule>): 
     }
   };
 
-  form.querySelectorAll<HTMLElement>("[name]").forEach((el) => {
+  root.querySelectorAll<HTMLElement>("[name]").forEach((el) => {
     const nm = (el as HTMLInputElement).name;
     if (!nm) return;
     const tk = templatePathFromIndexedPath(nm);
@@ -213,6 +238,19 @@ function validateForm(form: HTMLFormElement, rules: Record<string, FieldRule>): 
   });
 
   return errs;
+}
+
+function validateForm(form: HTMLFormElement, rules: Record<string, FieldRule>): Record<string, string> {
+  return collectNamedFieldErrors(form, rules);
+}
+
+function validateFormScoped(
+  _form: HTMLFormElement,
+  rules: Record<string, FieldRule>,
+  scope: Element | null,
+): Record<string, string> {
+  if (!scope) return {};
+  return collectNamedFieldErrors(scope, rules);
 }
 `;
 }
@@ -294,17 +332,24 @@ export function generateAppTsx(formModel: FormModel): string {
     )
     .join("\n");
 
+  const wizardStepCount = layout.steps?.length ?? 0;
+  const isWizardLayout = !!(layout.steps && layout.steps.length > 0);
+  const multiStepWizard = !!(layout.steps && layout.steps.length > 1);
+
   let formBody: string;
-  if (hasFields && layout.steps && layout.steps.length > 0) {
+  if (hasFields && isWizardLayout && layout.steps && multiStepWizard) {
     const sections = layout.steps
       .map((step: FormStep, stepIdx: number) => {
-        const stepFields = orderedFields.filter(
-          (f: FieldModel) => f.stepIndex === stepIdx || f.stepIndex === undefined,
-        );
+        const stepFields = pruneFieldsForWizardStep(orderedFields, stepIdx);
         const fieldComponents = stepFields
           .map((f: FieldModel) => generateFieldComponent(f, domIdByKey, undefined, repeaterStates))
           .join("\n\n");
-        return `<section className="form-section">
+        return `<section
+          className="form-section wizard-panel"
+          data-wizard-step={${stepIdx}}
+          hidden={wizardStep !== ${stepIdx}}
+          aria-hidden={wizardStep !== ${stepIdx}}
+        >
           <h2 className="section-title">
             <span className="section-number">${stepIdx + 1}</span>
             ${escapeHtml(step.title)}
@@ -316,8 +361,55 @@ export function generateAppTsx(formModel: FormModel): string {
       })
       .join("\n\n        ");
 
+    const submitBtnStyle = submitColor
+      ? `style={{ '--submit-bg-color': '${submitColor}' } as React.CSSProperties}`
+      : "";
+
     formBody = `<form ref={formRef} onInput={() => setFormTick((v) => v + 1)} onSubmit={handleSubmit} noValidate>
         ${sections}
+        <div className="wizard-footer">
+          {wizardStep > 0 ? (
+            <button
+              type="button"
+              className="wizard-btn wizard-btn-secondary"
+              onClick={() => {
+                setStatusMessage("");
+                setWizardStep((s) => Math.max(0, s - 1));
+              }}
+            >
+              Previous
+            </button>
+          ) : (
+            <span className="wizard-footer-spacer" aria-hidden />
+          )}
+          <div className="wizard-footer-actions">
+            {wizardStep < ${wizardStepCount - 1} ? (
+              <button type="button" className="wizard-btn wizard-btn-primary" onClick={handleWizardNext}>
+                Next
+              </button>
+            ) : null}
+            {wizardStep === ${wizardStepCount - 1} ? (
+              <button type="submit" className="submit-button" ${submitBtnStyle}>${escapeHtml(submitText)}</button>
+            ) : null}
+          </div>
+        </div>
+      </form>`;
+  } else if (hasFields && isWizardLayout && layout.steps?.length === 1) {
+    const soleStep = layout.steps[0]!;
+    const stepFields = pruneFieldsForWizardStep(orderedFields, 0);
+    const fieldComponents = stepFields
+      .map((f: FieldModel) => generateFieldComponent(f, domIdByKey, undefined, repeaterStates))
+      .join("\n\n");
+    formBody = `<form ref={formRef} onInput={() => setFormTick((v) => v + 1)} onSubmit={handleSubmit} noValidate>
+        <section className="form-section">
+          <h2 className="section-title">
+            <span className="section-number">1</span>
+            ${escapeHtml(soleStep.title)}
+          </h2>
+          <div className="section-fields">
+            ${fieldComponents}
+          </div>
+        </section>
         <button type="submit" className="submit-button" ${submitColor ? `style={{ '--submit-bg-color': '${submitColor}' } as React.CSSProperties}` : ""}>${escapeHtml(submitText)}</button>
       </form>`;
   } else if (hasFields) {
@@ -402,6 +494,90 @@ function syncSignaturePads(form: HTMLFormElement | null) {
 }
 `;
 
+  const wizardStepStateLine =
+    hasFields && multiStepWizard
+      ? `  const [wizardStep, setWizardStep] = useState(0);\n`
+      : "";
+
+  const wizardFocusEffect =
+    hasFields && multiStepWizard
+      ? `
+  useEffect(() => {
+    const form = formRef.current;
+    if (!form) return;
+    const panel = form.querySelector(\`[data-wizard-step="\${wizardStep}"]\`);
+    if (!panel) return;
+    const focusable = panel.querySelector<HTMLElement>(
+      'button:not([disabled]), [href], input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    focusable?.focus({ preventScroll: true });
+  }, [wizardStep]);
+`
+      : "";
+
+  const wizardSubmitGate =
+    hasFields && isWizardLayout && wizardStepCount > 1
+      ? `
+    if (wizardStep < ${wizardStepCount - 1}) {
+      handleWizardNext();
+      return;
+    }
+`
+      : "";
+
+  const handleWizardNextBlock =
+    hasFields && isWizardLayout && wizardStepCount > 1
+      ? `
+  const handleWizardNext = () => {
+    const form = formRef.current;
+    if (!form) return;
+    syncRichTextEditors(form);
+    syncSignaturePads(form);
+    const scope = form.querySelector(\`[data-wizard-step="\${wizardStep}"]\`);
+    const stepErrs = validateFormScoped(form, FIELD_RULES, scope);
+    setErrors(stepErrs);
+    const errorKeys = Object.keys(stepErrs);
+    if (errorKeys.length > 0) {
+      const firstKey = errorKeys[0];
+      const firstDetail = firstKey ? stepErrs[firstKey] : "";
+      setStatusKind("error");
+      setStatusMessage(
+        errorKeys.length === 1
+          ? firstDetail || "Please fix the highlighted field."
+          : errorKeys.length +
+              " errors found. " +
+              (firstDetail || "Please review the highlighted fields."),
+      );
+      if (firstKey) {
+        let focusEl: HTMLElement | null = null;
+        const els = form.elements;
+        for (let i = 0; i < els.length; i++) {
+          const fe = els[i];
+          if (
+            fe instanceof HTMLElement &&
+            "name" in fe &&
+            (fe as HTMLInputElement).name === firstKey
+          ) {
+            focusEl = fe;
+            break;
+          }
+        }
+        const tk = templatePathFromIndexedPath(firstKey);
+        const fallbackId = FIELD_ID_MAP[tk];
+        const el = focusEl ?? (fallbackId ? (document.getElementById(fallbackId) as HTMLElement | null) : null);
+        el?.focus();
+        el?.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+      return;
+    }
+    setErrors({});
+    setStatusMessage("");
+    setWizardStep((s) => s + 1);
+  };
+
+`
+      : "";
+
   const fieldRulesJson = buildClientFieldRulesJson(formModel);
 
   return `import React, { FormEvent, useState, useRef, useEffect } from 'react';
@@ -420,7 +596,7 @@ function App() {
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [statusMessage, setStatusMessage] = useState<string>('');
   const [statusKind, setStatusKind] = useState<'error' | 'success'>('error');
-${repeaterStateDeclarations ? `\n${repeaterStateDeclarations}\n` : ""}
+${wizardStepStateLine}${repeaterStateDeclarations ? `\n${repeaterStateDeclarations}\n` : ""}
 
   useEffect(() => {
     const form = formRef.current;
@@ -466,11 +642,11 @@ ${repeaterStateDeclarations ? `\n${repeaterStateDeclarations}\n` : ""}
     });
     return () => cleanups.forEach((c) => c());
   }, []);
-
+${wizardFocusEffect}${handleWizardNextBlock}
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     syncRichTextEditors(e.currentTarget);
-    syncSignaturePads(e.currentTarget);
+    syncSignaturePads(e.currentTarget);${wizardSubmitGate}
     const errs = validateForm(e.currentTarget, FIELD_RULES);
     setErrors(errs);
     const errorKeys = Object.keys(errs);

--- a/formsync/services/formgen-service/src/generators/react-generator.ts
+++ b/formsync/services/formgen-service/src/generators/react-generator.ts
@@ -280,19 +280,19 @@ function jsxRepeaterNameAttr(repeaterRoot: string, field: FieldModel): string {
   const rel = relativeUnderRepeater(repeaterRoot, field.key);
   const rootLit = repeaterRoot.replace(/\\/g, "\\\\").replace(/`/g, "\\`");
   const relLit = rel.replace(/\\/g, "\\\\").replace(/`/g, "\\`");
-  return `name={\\\`${rootLit}.\\\${rowIdx}.${relLit}\\\`}`;
+  return `name={\`${rootLit}.\${rowIdx}.${relLit}\`}`;
 }
 
 function jsxIdAttr(domBase: string, ctx?: RepeaterCodegenCtx): string {
   if (!ctx) return `id="${escapeHtml(domBase)}"`;
   const base = domBase.replace(/\\/g, "\\\\").replace(/`/g, "\\`");
-  return `id={\\\`${base}_\\\${rowIdx}\\\`}`;
+  return `id={\`${base}_\${rowIdx}\`}`;
 }
 
 function jsxHtmlForAttr(domBase: string, ctx?: RepeaterCodegenCtx): string {
   if (!ctx) return `htmlFor="${escapeHtml(domBase)}"`;
   const base = domBase.replace(/\\/g, "\\\\").replace(/`/g, "\\`");
-  return `htmlFor={\\\`${base}_\\\${rowIdx}\\\`}`;
+  return `htmlFor={\`${base}_\${rowIdx}\`}`;
 }
 
 function jsxErrorsLookup(repeaterRoot: string | undefined, field: FieldModel): string {
@@ -300,13 +300,13 @@ function jsxErrorsLookup(repeaterRoot: string | undefined, field: FieldModel): s
   const rel = relativeUnderRepeater(repeaterRoot, field.key);
   const rootLit = repeaterRoot.replace(/\\/g, "\\\\").replace(/`/g, "\\`");
   const relLit = rel.replace(/\\/g, "\\\\").replace(/`/g, "\\`");
-  return `errors[\\\`${rootLit}.\\\${rowIdx}.${relLit}\\\`]`;
+  return `errors[\`${rootLit}.\${rowIdx}.${relLit}\`]`;
 }
 
 function jsxAriaDescribedBy(domBase: string, ctx?: RepeaterCodegenCtx): string {
   if (!ctx) return `aria-describedby="${domBase}-help ${domBase}-error"`;
   const b = domBase.replace(/\\/g, "\\\\").replace(/`/g, "\\`");
-  return `aria-describedby={\\\`${b}_\\\${rowIdx}-help ${b}_\\\${rowIdx}-error\\\`}`;
+  return `aria-describedby={\`${b}_\${rowIdx}-help ${b}_\${rowIdx}-error\`}`;
 }
 
 export function generateAppTsx(formModel: FormModel): string {
@@ -749,7 +749,7 @@ function generateFieldComponent(
   const ariaDescribedBy = jsxAriaDescribedBy(domBase, ctx);
   const ariaInvalid = `aria-invalid={${errExpr} ? 'true' : 'false'}`;
   const ariaErrMsg = ctx
-    ? `aria-errormessage={\\\`${domBase.replace(/`/g, "\\`")}_\\\${rowIdx}-error\\\`}`
+    ? `aria-errormessage={\`${domBase.replace(/`/g, "\\`")}_\${rowIdx}-error\`}`
     : `aria-errormessage="${domBase}-error"`;
 
   if (type === "repeater") {
@@ -902,12 +902,12 @@ function generateFieldComponent(
 
   const helpSpan = helpText
     ? ctx
-      ? `<small id={\\\`${domBase.replace(/`/g, "\\`")}_\\\${rowIdx}-help\\\`} className="field-help-text">${escapeHtml(helpText)}</small>`
+      ? `<small id={\`${domBase.replace(/`/g, "\\`")}_\${rowIdx}-help\`} className="field-help-text">${escapeHtml(helpText)}</small>`
       : `<small id="${domBase}-help" className="field-help-text">${escapeHtml(helpText)}</small>`
     : "";
 
   const errSpan = ctx
-    ? `<span id={\\\`${domBase.replace(/`/g, "\\`")}_\\\${rowIdx}-error\\\`} className="field-error" role="alert" aria-live="polite">{${errExpr}}</span>`
+    ? `<span id={\`${domBase.replace(/`/g, "\\`")}_\${rowIdx}-error\`} className="field-error" role="alert" aria-live="polite">{${errExpr}}</span>`
     : `<span id="${domBase}-error" className="field-error" role="alert" aria-live="polite">{${errExpr}}</span>`;
 
   switch (type) {
@@ -987,7 +987,7 @@ function generateFieldComponent(
       const rowStyle = [`display: 'flex'`, `alignItems: 'center'`, `flexWrap: 'wrap'`];
       const cbHelpId =
         ctx ?
-          `id={\\\`${domBase.replace(/`/g, "\\`")}_\\\${rowIdx}-help\\\`}`
+          `id={\`${domBase.replace(/`/g, "\\`")}_\${rowIdx}-help\`}`
         : `id="${domBase}-help"`;
       const cbHelp = helpText
         ? `<small ${cbHelpId} className="field-help-text" style={{ marginLeft: 'auto' }}>${escapeHtml(helpText)}</small>`
@@ -1025,13 +1025,13 @@ function generateFieldComponent(
     case "signature": {
       const hidId = `${domBase}_sig`;
       const hidIdExpr = ctx
-        ? `{\\\`${domBase.replace(/`/g, "\\`")}_\\\${rowIdx}_sig\\\`}`
+        ? `{\`${domBase.replace(/`/g, "\\`")}_\${rowIdx}_sig\`}`
         : `"${escapeHtml(hidId)}"`;
       const canvasIdExpr = ctx
-        ? `{\\\`${domBase.replace(/`/g, "\\`")}_\\\${rowIdx}_canvas\\\`}`
+        ? `{\`${domBase.replace(/`/g, "\\`")}_\${rowIdx}_canvas\`}`
         : `"${escapeHtml(domBase)}_canvas"`;
       const sigTargetAttr = ctx
-        ? `data-fs-sig-target={\\\`${domBase.replace(/`/g, "\\`")}_\\\${rowIdx}_sig\\\`}`
+        ? `data-fs-sig-target={\`${domBase.replace(/`/g, "\\`")}_\${rowIdx}_sig\`}`
         : `data-fs-sig-target="${escapeHtml(hidId)}"`;
       const input = `<canvas
             id=${canvasIdExpr}
@@ -1071,7 +1071,7 @@ function generateFieldComponent(
       const url = ui?.["x-ui"]?.asyncSource?.url ?? "";
       const dlId = `${domBase}_dl`;
       const dlIdExpr = ctx
-        ? `{\\\`${domBase.replace(/`/g, "\\`")}_\\\${rowIdx}_dl\\\`}`
+        ? `{\`${domBase.replace(/`/g, "\\`")}_\${rowIdx}_dl\`}`
         : `"${escapeHtml(dlId)}"`;
       const input = `<input
             type="text"

--- a/formsync/services/formgen-service/src/generators/react-generator.ts
+++ b/formsync/services/formgen-service/src/generators/react-generator.ts
@@ -419,14 +419,18 @@ ${repeaterStateDeclarations ? `\n${repeaterStateDeclarations}\n` : ""}
     syncSignaturePads(e.currentTarget);
     const errs = validateForm(e.currentTarget, FIELD_RULES);
     setErrors(errs);
-    const errorCount = Object.keys(errs).length;
+    const errorKeys = Object.keys(errs);
+    const errorCount = errorKeys.length;
     if (errorCount > 0) {
+      const firstKey = errorKeys[0];
+      const firstDetail = firstKey ? errs[firstKey] : "";
       setStatusMessage(
         errorCount === 1
-          ? '1 error found. Please review the highlighted field.'
-          : errorCount + ' errors found. Please review the highlighted fields.'
+          ? firstDetail || "Please fix the highlighted field."
+          : errorCount +
+              " errors found. " +
+              (firstDetail || "Please review the highlighted fields."),
       );
-      const firstKey = Object.keys(errs)[0];
       if (firstKey) {
         let focusEl: HTMLElement | null = null;
         const els = e.currentTarget.elements;
@@ -449,6 +453,7 @@ ${repeaterStateDeclarations ? `\n${repeaterStateDeclarations}\n` : ""}
       }
       return;
     }
+    setErrors({});
     const formData = new FormData(e.currentTarget);
     const data = Object.fromEntries(formData.entries());
     /* FORMSYNC_API_SUBMIT_START */
@@ -459,9 +464,11 @@ ${repeaterStateDeclarations ? `\n${repeaterStateDeclarations}\n` : ""}
 
   return (
     <div className="form-container">
-      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
-        {statusMessage}
-      </div>
+      {statusMessage ? (
+        <div className="form-validation-summary" role="alert" aria-live="polite" aria-atomic="true">
+          {statusMessage}
+        </div>
+      ) : null}
       <h1 className="form-title">${escapeHtml(title)}</h1>
       ${description ? `<p className="form-description">${escapeHtml(description)}</p>` : ""}
       ${formBody}

--- a/formsync/services/formgen-service/src/generators/templates.ts
+++ b/formsync/services/formgen-service/src/generators/templates.ts
@@ -233,6 +233,101 @@ body {
   background: color-mix(in srgb, #16a34a 14%, transparent);
 }
 
+/* Success modal — shown after successful submit (demo or API) */
+.fs-success-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(4px);
+  animation: fs-success-fade-in 0.2s ease;
+}
+@keyframes fs-success-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+.fs-success-modal {
+  width: 100%;
+  max-width: 22rem;
+  padding: 1.75rem 1.5rem 1.25rem;
+  border-radius: calc(var(--border-radius) + 4px);
+  background: var(--color-surface);
+  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+  box-shadow:
+    0 25px 50px -12px rgba(0, 0, 0, 0.25),
+    0 0 0 1px color-mix(in srgb, #16a34a 15%, transparent);
+  text-align: center;
+  animation: fs-success-pop 0.28s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+@keyframes fs-success-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.92) translateY(0.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+.fs-success-modal-icon-wrap {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 0.75rem;
+}
+.fs-success-modal-icon {
+  width: 3rem;
+  height: 3rem;
+  color: #16a34a;
+}
+.fs-success-modal-title {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--color-text);
+  letter-spacing: -0.02em;
+}
+.fs-success-modal-text {
+  margin: 0 0 1.25rem;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--color-muted);
+}
+.fs-success-modal-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 7rem;
+  padding: 0.55rem 1.25rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  font-family: inherit;
+  color: #fff;
+  background: linear-gradient(180deg, #22c55e 0%, #16a34a 100%);
+  border: none;
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(22, 163, 74, 0.35);
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.12s ease;
+}
+.fs-success-modal-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px rgba(22, 163, 74, 0.45);
+}
+.fs-success-modal-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 /* Field Styling */
 .field-item {
   margin-bottom: 1.5rem;

--- a/formsync/services/formgen-service/src/generators/templates.ts
+++ b/formsync/services/formgen-service/src/generators/templates.ts
@@ -322,6 +322,29 @@ input[type="checkbox"].field-input {
   border: 0;
 }
 
+/* Repeater with ui.displayMode === "table" (generated App) */
+.repeater-data-table {
+  border: 1px solid var(--color-border);
+}
+.repeater-data-table th,
+.repeater-data-table td {
+  border: 1px solid var(--color-border);
+  padding: 0.5rem 0.65rem;
+  text-align: left;
+  vertical-align: middle;
+}
+.repeater-data-table thead th {
+  background: color-mix(in srgb, var(--color-surface) 88%, var(--color-border));
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+.repeater-table-cell .field-item {
+  margin-bottom: 0;
+}
+.repeater-table-actions {
+  text-align: right;
+}
+
 /* Grouped fields — theme-aware fieldset */
 .field-group {
   border: 1px solid var(--color-border);

--- a/formsync/services/formgen-service/src/generators/templates.ts
+++ b/formsync/services/formgen-service/src/generators/templates.ts
@@ -197,10 +197,12 @@ body {
 .form-container {
   max-width: 600px;
   width: 100%;
-  background: var(--color-bg);
+  /* Card/surface — distinct from page background (--color-bg on body) */
+  background: var(--color-surface);
   padding: 2rem;
   border-radius: var(--border-radius);
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  border: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
 }
 
 .form-title {

--- a/formsync/services/formgen-service/src/generators/templates.ts
+++ b/formsync/services/formgen-service/src/generators/templates.ts
@@ -217,6 +217,17 @@ body {
   margin-bottom: 2rem;
 }
 
+/* Visible summary when validation fails (supplements per-field .field-error text). */
+.form-validation-summary {
+  padding: 0.75rem 1rem;
+  margin-bottom: 1.25rem;
+  border-radius: var(--border-radius);
+  border: 1px solid color-mix(in srgb, var(--color-error) 45%, transparent);
+  background: color-mix(in srgb, var(--color-error) 12%, transparent);
+  color: var(--color-text);
+  font-size: 0.95rem;
+}
+
 /* Field Styling */
 .field-item {
   margin-bottom: 1.5rem;

--- a/formsync/services/formgen-service/src/generators/templates.ts
+++ b/formsync/services/formgen-service/src/generators/templates.ts
@@ -334,9 +334,11 @@ input[type="checkbox"].field-input {
   vertical-align: middle;
 }
 .repeater-data-table thead th {
-  background: color-mix(in srgb, var(--color-surface) 88%, var(--color-border));
-  font-weight: 600;
-  font-size: 0.85rem;
+  background: color-mix(in srgb, var(--color-surface) 82%, var(--color-border));
+  color: var(--color-text);
+  font-weight: 700;
+  font-size: 0.875rem;
+  letter-spacing: 0.02em;
 }
 .repeater-table-cell .field-item {
   margin-bottom: 0;

--- a/formsync/services/formgen-service/src/generators/templates.ts
+++ b/formsync/services/formgen-service/src/generators/templates.ts
@@ -492,6 +492,53 @@ canvas.field-input.signature-pad-canvas {
   flex-direction: column;
   gap: 0.25rem;
 }
+
+/* Wizard (generated React App — multi-step) */
+.wizard-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.wizard-footer-spacer {
+  flex: 1;
+  min-width: 0;
+}
+
+.wizard-footer-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-left: auto;
+}
+
+.wizard-btn {
+  padding: 0.6rem 1.25rem;
+  border-radius: var(--border-radius);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.wizard-btn-primary {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: var(--color-primary);
+}
+
+.wizard-btn-secondary {
+  background: var(--color-surface);
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+.wizard-btn:hover {
+  filter: brightness(1.05);
+}
 `;
 }
 

--- a/formsync/services/formgen-service/src/generators/templates.ts
+++ b/formsync/services/formgen-service/src/generators/templates.ts
@@ -280,6 +280,48 @@ input[type="checkbox"].field-input {
   color: var(--color-muted);
 }
 
+/* Rich text: toolbar + contenteditable (export uses document.execCommand) */
+.richtext-wrap {
+  width: 100%;
+}
+.richtext-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-bottom: 0.4rem;
+}
+.richtext-tool {
+  min-width: 2rem;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.8rem;
+  border: 1px solid var(--field-border-color, var(--color-border));
+  border-radius: var(--border-radius);
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+}
+.richtext-tool:hover {
+  background: color-mix(in srgb, var(--color-primary) 8%, var(--color-surface));
+}
+.richtext-editable.field-input {
+  min-height: 6rem;
+  overflow-y: auto;
+  line-height: 1.5;
+}
+.richtext-editable[contenteditable="true"]:empty:before {
+  content: attr(data-placeholder);
+  color: var(--color-muted);
+  pointer-events: none;
+}
+canvas.field-input.signature-pad-canvas {
+  display: block;
+  min-height: 10rem;
+  border: 2px solid var(--field-border-color, var(--color-border)) !important;
+  background: var(--field-bg-color, var(--color-input-bg)) !important;
+  border-radius: var(--border-radius);
+  cursor: crosshair;
+}
+
 .field-help-text {
   display: block;
   font-size: 0.875rem;

--- a/formsync/services/formgen-service/src/generators/templates.ts
+++ b/formsync/services/formgen-service/src/generators/templates.ts
@@ -228,6 +228,11 @@ body {
   font-size: 0.95rem;
 }
 
+.form-validation-summary.form-submit-success {
+  border-color: color-mix(in srgb, #16a34a 45%, transparent);
+  background: color-mix(in srgb, #16a34a 14%, transparent);
+}
+
 /* Field Styling */
 .field-item {
   margin-bottom: 1.5rem;

--- a/formsync/services/runtime-binding-engine/src/generator/SpringBootGenerator.ts
+++ b/formsync/services/runtime-binding-engine/src/generator/SpringBootGenerator.ts
@@ -9,11 +9,12 @@ import { TemplateService } from '../service/TemplateService';
 import { FileWriter } from '../service/FileWriter';
 import { ContextualTestGenerator } from '../service/ContextualTestGenerator';
 import * as path from 'path';
+import { sanitizeJavaBasePackage } from './javaPackageUtils';
 
 /** Derives a Java base package from a schema name (e.g. "Employee" -> "com.employee"). */
 function schemaNameToBasePackage(name: string): string {
     const normalized = name.toLowerCase().replace(/[^a-z0-9]/g, '') || 'app';
-    return `com.${normalized}`;
+    return sanitizeJavaBasePackage(`com.${normalized}`);
 }
 
 /**
@@ -66,7 +67,9 @@ export class SpringBootGenerator {
             }
 
             const appName = internalModel.appName;
-            const basePackage = config?.basePackage ?? schemaNameToBasePackage(appName);
+            const basePackage = sanitizeJavaBasePackage(
+                config?.basePackage ?? schemaNameToBasePackage(appName),
+            );
             const packagePath = basePackage.replace(/\./g, '/');
 
             // ── 1. pom.xml ──

--- a/formsync/services/runtime-binding-engine/src/generator/javaPackageUtils.spec.ts
+++ b/formsync/services/runtime-binding-engine/src/generator/javaPackageUtils.spec.ts
@@ -1,0 +1,26 @@
+import { sanitizeJavaBasePackage, sanitizeJavaPackageSegment } from './javaPackageUtils';
+
+describe('javaPackageUtils', () => {
+    it('suffixes reserved keyword segments so package declarations compile', () => {
+        expect(sanitizeJavaBasePackage('com.new')).toBe('com.new_');
+        expect(sanitizeJavaBasePackage('com.int')).toBe('com.int_');
+        expect(sanitizeJavaBasePackage('com.class')).toBe('com.class_');
+        expect(sanitizeJavaBasePackage('com.package')).toBe('com.package_');
+    });
+
+    it('leaves safe segments unchanged', () => {
+        expect(sanitizeJavaBasePackage('com.example.demo')).toBe('com.example.demo');
+        expect(sanitizeJavaBasePackage('com.employee')).toBe('com.employee');
+    });
+
+    it('sanitizeJavaPackageSegment appends underscore only for reserved words', () => {
+        expect(sanitizeJavaPackageSegment('new')).toBe('new_');
+        expect(sanitizeJavaPackageSegment('news')).toBe('news');
+        expect(sanitizeJavaPackageSegment('New')).toBe('New_');
+    });
+
+    it('handles empty input', () => {
+        expect(sanitizeJavaBasePackage('')).toBe('com.app');
+        expect(sanitizeJavaBasePackage('...')).toBe('com.app');
+    });
+});

--- a/formsync/services/runtime-binding-engine/src/generator/javaPackageUtils.ts
+++ b/formsync/services/runtime-binding-engine/src/generator/javaPackageUtils.ts
@@ -1,0 +1,97 @@
+/**
+ * Java reserved keywords and boolean/null literals that cannot appear alone
+ * as a package name segment (JLS identifier rules).
+ */
+const JAVA_PACKAGE_SEGMENT_FORBIDDEN = new Set([
+    'abstract',
+    'assert',
+    'boolean',
+    'break',
+    'byte',
+    'case',
+    'catch',
+    'char',
+    'class',
+    'const',
+    'continue',
+    'default',
+    'do',
+    'double',
+    'else',
+    'enum',
+    'extends',
+    'final',
+    'finally',
+    'float',
+    'for',
+    'goto',
+    'if',
+    'implements',
+    'import',
+    'instanceof',
+    'int',
+    'interface',
+    'long',
+    'native',
+    'new',
+    'package',
+    'private',
+    'protected',
+    'public',
+    'return',
+    'short',
+    'static',
+    'strictfp',
+    'super',
+    'switch',
+    'synchronized',
+    'this',
+    'throw',
+    'throws',
+    'transient',
+    'try',
+    'void',
+    'volatile',
+    'while',
+    'true',
+    'false',
+    'null',
+    'var',
+    'yield',
+    'record',
+    'sealed',
+    'permits',
+    'non-sealed',
+    'nonsealed',
+    'module',
+    'exports',
+    'opens',
+    'requires',
+    'uses',
+    'provides',
+    'transitive',
+    'open',
+    'to',
+    'with',
+]);
+
+/** Ensures a package segment is not a reserved word (e.g. `new` → `new_`). */
+export function sanitizeJavaPackageSegment(segment: string): string {
+    const s = segment.trim();
+    if (!s) return 'pkg';
+    if (JAVA_PACKAGE_SEGMENT_FORBIDDEN.has(s.toLowerCase())) {
+        return `${s}_`;
+    }
+    return s;
+}
+
+/** Sanitizes a full base package (e.g. `com.new` → `com.new_`). */
+export function sanitizeJavaBasePackage(basePackage: string): string {
+    const parts = basePackage
+        .split('.')
+        .map((p) => p.trim())
+        .filter((p) => p.length > 0)
+        .map(sanitizeJavaPackageSegment);
+    if (parts.length === 0) return 'com.app';
+    return parts.join('.');
+}

--- a/formsync/services/runtime-binding-engine/src/service/TemplateService.ts
+++ b/formsync/services/runtime-binding-engine/src/service/TemplateService.ts
@@ -103,6 +103,11 @@ export class TemplateService {
             return (arg1 === arg2) ? options.fn(this) : options.inverse(this);
         });
 
+        handlebars.registerHelper('endsWith', (str: string, suffix: string) => {
+            if (str == null || suffix == null) return false;
+            return String(str).endsWith(String(suffix));
+        });
+
         handlebars.registerHelper('toPackagePath', (pkg: string) => {
             return pkg ? pkg.replace(/\./g, '/') : '';
         });
@@ -286,6 +291,23 @@ export class TemplateService {
         });
 
         // ── Type mapping helper ─────────────────────────────────
+
+        /** True when List&lt;T&gt; uses a nested @Embeddable type (vs String, Integer, …). */
+        const LIST_ELEMENT_BASIC_TYPES = new Set([
+            'String',
+            'Integer',
+            'Long',
+            'Double',
+            'Boolean',
+            'BigDecimal',
+            'LocalDate',
+            'LocalDateTime',
+        ]);
+
+        handlebars.registerHelper('listElementIsEmbeddable', (referenceType?: string) => {
+            const rt = referenceType ?? 'String';
+            return !LIST_ELEMENT_BASIC_TYPES.has(rt);
+        });
 
         handlebars.registerHelper('toJavaType', (type: DataType, referenceType?: string) => {
             let result: string;

--- a/formsync/services/runtime-binding-engine/src/service/entityTemplateRepeater.golden.spec.ts
+++ b/formsync/services/runtime-binding-engine/src/service/entityTemplateRepeater.golden.spec.ts
@@ -1,0 +1,112 @@
+import { SchemaMapper } from '@formsync/schema-openapi';
+import type { SchemaPayload } from '@formsync/schema-openapi';
+import { TemplateService } from './TemplateService';
+
+/**
+ * Golden checks for Spring JPA entity emission when the schema includes a repeater
+ * (JSON Schema array of objects). Guards joinColumns on @ElementCollection and correct
+ * PascalCase embeddable names after SchemaMapper.toJavaClassName.
+ */
+describe('entity template — repeater / ElementCollection', () => {
+    const fixture: SchemaPayload = {
+        name: 'NewForm',
+        version: '1.0.0',
+        content: {
+            type: 'object',
+            properties: {
+                fullName: { type: 'string' },
+                repeatingTable: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: {
+                            text: { type: 'string' },
+                            textArea: { type: 'string' },
+                            number: { type: 'number' },
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    it('maps array-of-object items to RepeatingTableItem and emits joinColumns + List<T>', () => {
+        const mapper = new SchemaMapper();
+        const internal = mapper.map(fixture);
+
+        const itemEntity = internal.entities.find((e) => e.name === 'RepeatingTableItem');
+        expect(itemEntity).toBeDefined();
+        expect(itemEntity!.fields.map((f) => f.name).sort()).toEqual(['number', 'text', 'textArea']);
+
+        const root = internal.entities.find((e) => e.name === 'NewForm');
+        expect(root).toBeDefined();
+        const rtField = root!.fields.find((f) => f.name === 'repeatingTable');
+        expect(rtField?.referenceType).toBe('RepeatingTableItem');
+
+        const templates = new TemplateService();
+
+        const rootJava = templates.render('entity', {
+            ...root!,
+            basePackage: 'com.example',
+            nameLower: 'newForm',
+            includeSwagger: false,
+            appName: internal.appName,
+            version: internal.version,
+            description: internal.description,
+        });
+
+        expect(rootJava).toContain('joinColumns = @JoinColumn(name = "new_form_id")');
+        expect(rootJava).toContain('List<RepeatingTableItem>');
+        expect(rootJava).toContain('name = "new_form_repeating_table"');
+
+        const itemJava = templates.render('entity', {
+            ...itemEntity!,
+            basePackage: 'com.example',
+            nameLower: 'repeatingTableItem',
+            includeSwagger: false,
+            appName: internal.appName,
+            version: internal.version,
+            description: itemEntity!.description,
+        });
+
+        expect(itemJava).toContain('@Embeddable');
+        expect(itemJava).toContain('class RepeatingTableItem');
+        expect(itemJava).toContain('private String text');
+        expect(itemJava).toContain('private Double number');
+    });
+
+    it('List<String> ElementCollection includes value column for Hibernate basic collections', () => {
+        const payload: SchemaPayload = {
+            name: 'TagHolder',
+            content: {
+                type: 'object',
+                properties: {
+                    tags: {
+                        type: 'array',
+                        items: { type: 'string' },
+                    },
+                },
+            },
+        };
+
+        const mapper = new SchemaMapper();
+        const internal = mapper.map(payload);
+        const root = internal.entities.find((e) => e.name === 'TagHolder');
+        expect(root?.fields.find((f) => f.name === 'tags')?.referenceType).toBe('String');
+
+        const templates = new TemplateService();
+        const java = templates.render('entity', {
+            ...root!,
+            basePackage: 'com.example',
+            nameLower: 'tagHolder',
+            includeSwagger: false,
+            appName: internal.appName,
+            version: internal.version,
+            description: internal.description,
+        });
+
+        expect(java).toContain('joinColumns = @JoinColumn(name = "tag_holder_id")');
+        expect(java).toContain('@Column(name = "tags_val")');
+        expect(java).toContain('List<String>');
+    });
+});

--- a/formsync/services/runtime-binding-engine/src/service/entityTemplateRepeater.golden.spec.ts
+++ b/formsync/services/runtime-binding-engine/src/service/entityTemplateRepeater.golden.spec.ts
@@ -55,7 +55,9 @@ describe('entity template — repeater / ElementCollection', () => {
             description: internal.description,
         });
 
-        expect(rootJava).toContain('joinColumns = @JoinColumn(name = "new_form_id")');
+        expect(rootJava).toContain(
+            'joinColumns = @JoinColumn(name = "new_form_id", referencedColumnName = "id")',
+        );
         expect(rootJava).toContain('List<RepeatingTableItem>');
         expect(rootJava).toContain('name = "new_form_repeating_table"');
 
@@ -105,8 +107,44 @@ describe('entity template — repeater / ElementCollection', () => {
             description: internal.description,
         });
 
-        expect(java).toContain('joinColumns = @JoinColumn(name = "tag_holder_id")');
+        expect(java).toContain(
+            'joinColumns = @JoinColumn(name = "tag_holder_id", referencedColumnName = "id")',
+        );
         expect(java).toContain('@Column(name = "tags_val")');
         expect(java).toContain('List<String>');
+    });
+
+    it('empty repeater row embeddable gets a placeholder column for Hibernate', () => {
+        const payload: SchemaPayload = {
+            name: 'JobApplication',
+            content: {
+                type: 'object',
+                properties: {
+                    repeatingTable: {
+                        type: 'array',
+                        items: { type: 'object', properties: {} },
+                    },
+                },
+            },
+        };
+
+        const mapper = new SchemaMapper();
+        const internal = mapper.map(payload);
+        const itemEntity = internal.entities.find((e) => e.name === 'RepeatingTableItem');
+        expect(itemEntity?.fields.length).toBe(0);
+
+        const templates = new TemplateService();
+        const itemJava = templates.render('entity', {
+            ...itemEntity!,
+            basePackage: 'com.example',
+            nameLower: 'repeatingTableItem',
+            includeSwagger: false,
+            appName: internal.appName,
+            version: internal.version,
+            description: itemEntity!.description,
+        });
+
+        expect(itemJava).toContain('formsyncRowPlaceholder');
+        expect(itemJava).toContain('formsync_row_placeholder');
     });
 });

--- a/formsync/services/runtime-binding-engine/src/templates/java/dto-request.hbs
+++ b/formsync/services/runtime-binding-engine/src/templates/java/dto-request.hbs
@@ -23,12 +23,14 @@ import java.math.*;
 @Data
 @Builder
 @NoArgsConstructor
+{{#if fields.length}}
 @AllArgsConstructor
+{{/if}}
 public class {{name}}Request {
 
 {{#each fields}}
 {{#if ../includeSwagger}}
-    @Schema(description = "{{#if description}}{{description}}{{else}}{{name}} field{{/if}}"{{#if constraints.required}}, required = true{{/if}}{{#if constraints.example}}, example = "{{escapeSchemaExample constraints.example}}"{{/if}})
+    @Schema(description = "{{#if description}}{{description}}{{else}}{{name}} field{{/if}}"{{#if constraints.required}}, requiredMode = Schema.RequiredMode.REQUIRED{{/if}}{{#if constraints.example}}, example = "{{escapeSchemaExample constraints.example}}"{{/if}})
 {{/if}}
 {{#if description}}
     /**

--- a/formsync/services/runtime-binding-engine/src/templates/java/entity.hbs
+++ b/formsync/services/runtime-binding-engine/src/templates/java/entity.hbs
@@ -91,8 +91,16 @@ public class {{name}} {
     @Embedded
 {{else}}
 {{#eq type 'List'}}
+{{#if ../isRoot}}
+    @ElementCollection
+    @CollectionTable(name = "{{toSnakeCase ../name}}_{{toSnakeCase name}}", joinColumns = @JoinColumn(name = "{{toSnakeCase ../name}}_id"))
+{{#unless (listElementIsEmbeddable referenceType)}}
+    @Column(name = "{{toSnakeCase name}}_val")
+{{/unless}}
+{{else}}
     @ElementCollection
     @CollectionTable(name = "{{toSnakeCase ../name}}_{{toSnakeCase name}}")
+{{/if}}
 {{else}}
 {{#eq type 'Enum'}}
     @Enumerated(EnumType.STRING)

--- a/formsync/services/runtime-binding-engine/src/templates/java/entity.hbs
+++ b/formsync/services/runtime-binding-engine/src/templates/java/entity.hbs
@@ -20,7 +20,14 @@ import java.math.*;
 @Data
 @Builder
 @NoArgsConstructor
+{{!-- Omit @AllArgsConstructor when embeddable has no fields: Lombok would duplicate the no-arg ctor with @NoArgsConstructor. --}}
+{{#if isRoot}}
 @AllArgsConstructor
+{{else}}
+{{#if fields.length}}
+@AllArgsConstructor
+{{/if}}
+{{/if}}
 {{#if isRoot}}
 @Entity
 @Table(name = "{{toSnakeCase name}}")

--- a/formsync/services/runtime-binding-engine/src/templates/java/entity.hbs
+++ b/formsync/services/runtime-binding-engine/src/templates/java/entity.hbs
@@ -87,13 +87,19 @@ public class {{name}} {
 {{#if constraints.pattern}}
     @Pattern(regexp = "{{escapeJava constraints.pattern}}", message = "{{name}} must match the required pattern")
 {{/if}}
+{{#if persistAsLob}}
+    @Lob
+{{/if}}
 {{#eq type 'Object'}}
     @Embedded
 {{else}}
 {{#eq type 'List'}}
 {{#if ../isRoot}}
     @ElementCollection
-    @CollectionTable(name = "{{toSnakeCase ../name}}_{{toSnakeCase name}}", joinColumns = @JoinColumn(name = "{{toSnakeCase ../name}}_id"))
+    @CollectionTable(
+        name = "{{toSnakeCase ../name}}_{{toSnakeCase name}}",
+        joinColumns = @JoinColumn(name = "{{toSnakeCase ../name}}_id", referencedColumnName = "id")
+    )
 {{#unless (listElementIsEmbeddable referenceType)}}
     @Column(name = "{{toSnakeCase name}}_val")
 {{/unless}}
@@ -117,4 +123,17 @@ public class {{name}} {
     private {{toJavaType type referenceType}} {{name}};
 
 {{/each}}
+{{#unless isRoot}}
+{{#unless fields.length}}
+{{#if (endsWith name "Item")}}
+    /**
+     * Repeater row embeddable with no columns yet: Hibernate cannot map an empty embeddable
+     * in ElementCollection. Remove this field after adding repeater columns in the builder.
+     */
+    @Column(name = "formsync_row_placeholder", nullable = true)
+    private String formsyncRowPlaceholder;
+
+{{/if}}
+{{/unless}}
+{{/unless}}
 }

--- a/formsync/services/schema-openapi/src/InternalModel.ts
+++ b/formsync/services/schema-openapi/src/InternalModel.ts
@@ -44,6 +44,8 @@ export interface SchemaField {
     itemReferenceType?: string;
     description?: string;
     constraints: ValidationConstraints;
+    /** When true, JPA entity template emits @Lob (TEXT/CLOB) for large string payloads. */
+    persistAsLob?: boolean;
     relation?: {
         type: 'OneToOne' | 'OneToMany' | 'ManyToOne' | 'ManyToMany';
         targetEntity: string;

--- a/formsync/services/schema-openapi/src/SchemaMapper.spec.ts
+++ b/formsync/services/schema-openapi/src/SchemaMapper.spec.ts
@@ -49,6 +49,28 @@ describe('SchemaMapper', () => {
         expect(ageField?.constraints.max).toBe(150);
     });
 
+    it('should set persistAsLob for x-field-type signature, file, and richtext', () => {
+        const payload: SchemaPayload = {
+            name: 'Jobs',
+            content: {
+                type: 'object',
+                properties: {
+                    signaturePad: { type: 'string', 'x-field-type': 'signature' },
+                    attachment: { type: 'string', 'x-field-type': 'file' },
+                    notes: { type: 'string', 'x-field-type': 'richtext' },
+                    title: { type: 'string', 'x-field-type': 'typeahead' },
+                },
+            },
+        };
+
+        const result = mapper.map(payload);
+        const fields = result.entities[0].fields;
+        expect(fields.find((f) => f.name === 'signaturePad')?.persistAsLob).toBe(true);
+        expect(fields.find((f) => f.name === 'attachment')?.persistAsLob).toBe(true);
+        expect(fields.find((f) => f.name === 'notes')?.persistAsLob).toBe(true);
+        expect(fields.find((f) => f.name === 'title')?.persistAsLob).toBeFalsy();
+    });
+
     it('should map email format to email constraint', () => {
         const payload: SchemaPayload = {
             name: 'User',

--- a/formsync/services/schema-openapi/src/SchemaMapper.spec.ts
+++ b/formsync/services/schema-openapi/src/SchemaMapper.spec.ts
@@ -93,6 +93,37 @@ describe('SchemaMapper', () => {
         expect(numField?.constraints.max).toBe(1000000);
     });
 
+    it('should map array of objects to List with PascalCase item embeddable name', () => {
+        const payload: SchemaPayload = {
+            name: 'NewForm',
+            content: {
+                type: 'object',
+                properties: {
+                    repeatingTable: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                text: { type: 'string' },
+                                age: { type: 'integer' },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        const result = mapper.map(payload);
+        const itemEntity = result.entities.find((e) => e.name === 'RepeatingTableItem');
+        expect(itemEntity).toBeDefined();
+        expect(itemEntity?.fields.map((f) => f.name).sort()).toEqual(['age', 'text']);
+
+        const root = result.entities.find((e) => e.name === 'NewForm');
+        const rtField = root?.fields.find((f) => f.name === 'repeatingTable');
+        expect(rtField?.type).toBe(DataType.LIST);
+        expect(rtField?.referenceType).toBe('RepeatingTableItem');
+    });
+
     it('should map nested objects to separate entities', () => {
         const payload: SchemaPayload = {
             name: 'Order',

--- a/formsync/services/schema-openapi/src/SchemaMapper.ts
+++ b/formsync/services/schema-openapi/src/SchemaMapper.ts
@@ -118,7 +118,7 @@ export class SchemaMapper {
             case 'object':
                 type = DataType.OBJECT;
                 {
-                    const entityName = this.capitalize(name);
+                    const entityName = this.toJavaClassName(name);
                     this.parseEntity(entityName, schema, entities, enums);
                     referenceType = entityName;
                 }
@@ -187,10 +187,31 @@ export class SchemaMapper {
         return map[type] || 'String';
     }
 
+    /**
+     * PascalCase for enum names and simple tokens (split on spaces/dashes/underscores only).
+     */
     private capitalize(s: string): string {
         return s
             .split(/[\s_-]+/)
-            .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+            .join('');
+    }
+
+    /**
+     * Java class name from a JSON property key or synthetic name (handles camelCase like repeatingTableItem).
+     */
+    private toJavaClassName(identifier: string): string {
+        const s = identifier.trim();
+        if (!s) return 'Generated';
+        const words = s
+            .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+            .replace(/[_\s-]+/g, ' ')
+            .trim()
+            .split(/\s+/)
+            .filter(Boolean);
+        if (words.length === 0) return 'Generated';
+        return words
+            .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
             .join('');
     }
 }

--- a/formsync/services/schema-openapi/src/SchemaMapper.ts
+++ b/formsync/services/schema-openapi/src/SchemaMapper.ts
@@ -96,6 +96,9 @@ export class SchemaMapper {
         let itemType: DataType | undefined;
         let itemReferenceType: string | undefined;
 
+        const xFieldType =
+            typeof schema['x-field-type'] === 'string' ? (schema['x-field-type'] as string).toLowerCase() : '';
+
         switch (schema.type) {
             case 'integer':
                 type = DataType.INTEGER;
@@ -145,6 +148,10 @@ export class SchemaMapper {
                 type = DataType.STRING;
         }
 
+        const persistAsLob =
+            type === DataType.STRING &&
+            (xFieldType === 'signature' || xFieldType === 'file' || xFieldType === 'richtext');
+
         return {
             name: this.jsonPropertyKeyToJavaIdentifier(name),
             type,
@@ -152,7 +159,8 @@ export class SchemaMapper {
             itemType,
             itemReferenceType,
             description: schema.description,
-            constraints
+            constraints,
+            ...(persistAsLob ? { persistAsLob: true } : {}),
         };
     }
 

--- a/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
+++ b/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
@@ -116,6 +116,15 @@ function buildVanillaClientValidationSource(): string {
     }).join(".");
   }
 
+  function resolveRuleFromKeys(rules, tk) {
+    var r = rules[tk];
+    if (r) return r;
+    var parts = tk.split(".").filter(function (p) {
+      return p;
+    });
+    return parts.length ? rules[parts[parts.length - 1]] : undefined;
+  }
+
   function collectNamedFieldErrors(root, rules) {
     var errs = {};
     var emailRe = /^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/;
@@ -180,7 +189,7 @@ function buildVanillaClientValidationSource(): string {
       var nm = el.name;
       if (!nm) continue;
       var tk = templatePathFromIndexedPath(nm);
-      var rule = rules[tk];
+      var rule = resolveRuleFromKeys(rules, tk);
       if (!rule) continue;
 
       var tag = el.tagName.toLowerCase();
@@ -960,7 +969,6 @@ const STATIC_RUNTIME_HELPERS = `
       var rowsC = fs.querySelector('.repeater-rows');
       var template = rowsC ? rowsC.querySelector('.repeater-row') : null;
       var addBtn = fs.querySelector('.fs-repeater-add');
-      var remBtn = fs.querySelector('.fs-repeater-remove');
       if (!rowsC || !template || !addBtn) return;
 
       function refreshRemoveButtons() {
@@ -969,7 +977,10 @@ const STATIC_RUNTIME_HELPERS = `
           row.setAttribute('data-row-index', String(i));
           setRepeaterRowIndex(row, root, i);
         });
-        if (remBtn) remBtn.style.display = rows.length > 1 ? 'inline-block' : 'none';
+        var show = rows.length > 1;
+        fs.querySelectorAll('.fs-repeater-remove').forEach(function (btn) {
+          btn.style.display = show ? 'inline-block' : 'none';
+        });
       }
 
       addBtn.addEventListener('click', function () {
@@ -982,14 +993,22 @@ const STATIC_RUNTIME_HELPERS = `
         refreshRemoveButtons();
       });
 
-      if (remBtn) {
-        remBtn.addEventListener('click', function () {
-          var rows = rowsC.querySelectorAll('.repeater-row');
-          if (rows.length <= 1) return;
-          rows[rows.length - 1].remove();
-          refreshRemoveButtons();
-        });
-      }
+      fs.addEventListener('click', function (e) {
+        var t = e.target;
+        if (!t || typeof t.closest !== 'function') return;
+        var btn = t.closest('.fs-repeater-remove');
+        if (!btn || !fs.contains(btn)) return;
+        e.preventDefault();
+        var rows = rowsC.querySelectorAll('.repeater-row');
+        if (rows.length <= 1) return;
+        var row = btn.closest('.repeater-row');
+        if (!row || !rowsC.contains(row)) {
+          row = rows[rows.length - 1];
+        }
+        row.remove();
+        updateCalculatedFields(form);
+        refreshRemoveButtons();
+      });
 
       refreshRemoveButtons();
     });

--- a/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
+++ b/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
@@ -34,6 +34,31 @@ export interface RepeaterCtx {
   rowIdx: number;
 }
 
+/** Wizard step slice — nested group/repeater children use stepIndex ?? 0. */
+function pruneFieldsForWizardStep(fields: FieldModel[], stepIdx: number): FieldModel[] {
+  const out: FieldModel[] = [];
+  for (const f of fields) {
+    if (f.type === "group" && f.children?.length) {
+      const children = pruneFieldsForWizardStep(f.children, stepIdx);
+      if (children.length > 0) {
+        out.push({ ...f, children });
+      }
+      continue;
+    }
+    if (f.type === "repeater" && f.children?.length) {
+      const children = pruneFieldsForWizardStep(f.children, stepIdx);
+      if (children.length > 0) {
+        out.push({ ...f, children });
+      }
+      continue;
+    }
+    if ((f.stepIndex ?? 0) === stepIdx) {
+      out.push(f);
+    }
+  }
+  return out;
+}
+
 function escapeHtml(text: string): string {
   const map: Record<string, string> = {
     "&": "&amp;",
@@ -91,7 +116,7 @@ function buildVanillaClientValidationSource(): string {
     }).join(".");
   }
 
-  function validateForm(form, rules) {
+  function collectNamedFieldErrors(root, rules) {
     var errs = {};
     var emailRe = /^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/;
 
@@ -149,7 +174,7 @@ function buildVanillaClientValidationSource(): string {
       }
     }
 
-    var named = form.querySelectorAll("[name]");
+    var named = root.querySelectorAll("[name]");
     for (var i = 0; i < named.length; i++) {
       var el = named[i];
       var nm = el.name;
@@ -192,6 +217,15 @@ function buildVanillaClientValidationSource(): string {
     }
 
     return errs;
+  }
+
+  function validateForm(form, rules) {
+    return collectNamedFieldErrors(form, rules);
+  }
+
+  function validateFormScoped(form, rules, scope) {
+    if (!scope) return {};
+    return collectNamedFieldErrors(scope, rules);
   }
 `;
 }
@@ -620,22 +654,50 @@ function buildFormBody(formModel: FormModel, domIdByKey: Map<string, string>): s
   }
 
   if (layout.steps && layout.steps.length > 0) {
-    const sections = layout.steps.map((step, stepIdx) => {
-      const stepFields = orderedFields.filter(
-        (f) => f.stepIndex === stepIdx || f.stepIndex === undefined,
-      );
+    const stepCount = layout.steps.length;
+    const multiWizard = stepCount > 1;
+
+    if (stepCount === 1) {
+      const sole = layout.steps[0]!;
+      const stepFields = pruneFieldsForWizardStep(orderedFields, 0);
       const inner = stepFields.map((f) => generateBootstrapField(f, domIdByKey)).join("\n");
-      return `<div class="card mb-4">
+      return `<div class="fs-form-panel rounded shadow-sm p-4 mb-4">
+<form id="main-form" novalidate>
+  <div class="card mb-4" role="region" aria-label="${escapeHtml(sole.title)}">
+    <div class="card-header fw-semibold"><span class="badge bg-primary me-2">1</span>${escapeHtml(sole.title)}</div>
+    <div class="card-body">
+      ${inner}
+    </div>
+  </div>
+  <button type="submit" class="btn btn-primary"${btnStyle}>${escapeHtml(submitText)}</button>
+</form>
+</div>`;
+    }
+
+    const sections = layout.steps.map((step, stepIdx) => {
+      const stepFields = pruneFieldsForWizardStep(orderedFields, stepIdx);
+      const inner = stepFields.map((f) => generateBootstrapField(f, domIdByKey)).join("\n");
+      const hidePanel = stepIdx > 0 ? " d-none" : "";
+      return `<div class="card mb-4 fs-wizard-panel${hidePanel}" data-wizard-step="${stepIdx}" role="region" aria-label="${escapeHtml(step.title)}">
   <div class="card-header fw-semibold"><span class="badge bg-primary me-2">${stepIdx + 1}</span>${escapeHtml(step.title)}</div>
   <div class="card-body">
     ${inner}
   </div>
 </div>`;
     });
+
+    const footer = `<div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mt-3 pt-2 border-top">
+  <button type="button" class="btn btn-outline-secondary" id="wizard-prev" style="visibility:hidden">Previous</button>
+  <div class="d-flex gap-2 ms-auto">
+    <button type="button" class="btn btn-primary" id="wizard-next">Next</button>
+    <button type="submit" class="btn btn-primary" id="wizard-submit"${btnStyle} style="display:none">${escapeHtml(submitText)}</button>
+  </div>
+</div>`;
+
     return `<div class="fs-form-panel rounded shadow-sm p-4 mb-4">
 <form id="main-form" novalidate>
   ${sections.join("\n")}
-  <button type="submit" class="btn btn-primary"${btnStyle}>${escapeHtml(submitText)}</button>
+  ${footer}
 </form>
 </div>`;
   }
@@ -994,11 +1056,136 @@ const STATIC_RUNTIME_HELPERS = `
   }
 `;
 
+/** Vanilla wizard wiring when layout has more than one step (must run before submit listener). */
+function buildMultiWizardInstallJs(formModel: FormModel): string {
+  const steps = formModel.layout.steps;
+  if (!steps || steps.length <= 1) return "";
+
+  const n = steps.length;
+  return `
+  var WIZARD_STEP_COUNT = ${n};
+  var wizardStep = 0;
+  var wizardPanels = Array.prototype.slice.call(form.querySelectorAll(".fs-wizard-panel"));
+  var btnPrev = document.getElementById("wizard-prev");
+  var btnNext = document.getElementById("wizard-next");
+  var btnSubmit = document.getElementById("wizard-submit");
+
+  function focusActiveWizardPanel() {
+    var panel = form.querySelector('[data-wizard-step="' + wizardStep + '"]');
+    if (!panel) return;
+    var focusable = panel.querySelector(
+      'button:not([disabled]), [href], input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    );
+    if (focusable && focusable.focus) {
+      focusable.focus({ preventScroll: true });
+    }
+  }
+
+  function applyWizardView() {
+    for (var pi = 0; pi < wizardPanels.length; pi++) {
+      if (pi === wizardStep) {
+        wizardPanels[pi].classList.remove("d-none");
+      } else {
+        wizardPanels[pi].classList.add("d-none");
+      }
+    }
+    if (btnPrev) {
+      btnPrev.style.visibility = wizardStep === 0 ? "hidden" : "visible";
+    }
+    if (btnNext && btnSubmit) {
+      var last = wizardStep >= WIZARD_STEP_COUNT - 1;
+      btnNext.hidden = last;
+      btnSubmit.hidden = !last;
+    }
+    focusActiveWizardPanel();
+  }
+
+  function tryWizardNext() {
+    syncRichTextEditors(form);
+    syncSignaturePads(form);
+    var scope = form.querySelector('[data-wizard-step="' + wizardStep + '"]');
+    var stepErrs = validateFormScoped(form, FIELD_RULES, scope);
+    var errorKeys = Object.keys(stepErrs);
+    if (errorKeys.length > 0) {
+      applyInlineFieldErrors(form, stepErrs);
+      var statusEl = document.getElementById("form-status");
+      var firstKey = errorKeys[0];
+      var firstMsg = firstKey ? stepErrs[firstKey] : "";
+      if (statusEl) {
+        statusEl.textContent =
+          errorKeys.length === 1
+            ? firstMsg || "Please fix the highlighted field."
+            : errorKeys.length +
+                " errors found. " +
+                (firstMsg || "Please review the highlighted fields.");
+        statusEl.className = "alert alert-danger mb-3";
+      }
+      var focusEl = null;
+      var els = form.elements;
+      for (var fi = 0; fi < els.length; fi++) {
+        var fe = els[fi];
+        if (fe.name === firstKey) {
+          focusEl = fe;
+          break;
+        }
+      }
+      var tk = firstKey ? templatePathFromIndexedPath(firstKey) : "";
+      var fallbackId = tk ? FIELD_ID_MAP[tk] : "";
+      var el = focusEl || (fallbackId ? document.getElementById(fallbackId) : null);
+      if (el && el.focus) {
+        el.focus();
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+      return;
+    }
+    clearInlineFieldErrors(form);
+    var st = document.getElementById("form-status");
+    if (st) {
+      st.textContent = "";
+      st.className = "mb-3";
+    }
+    wizardStep += 1;
+    applyWizardView();
+  }
+
+  if (btnPrev) {
+    btnPrev.addEventListener("click", function () {
+      if (wizardStep > 0) {
+        wizardStep -= 1;
+        applyWizardView();
+        var st2 = document.getElementById("form-status");
+        if (st2) {
+          st2.textContent = "";
+          st2.className = "mb-3";
+        }
+        clearInlineFieldErrors(form);
+      }
+    });
+  }
+  if (btnNext) {
+    btnNext.addEventListener("click", function () {
+      tryWizardNext();
+    });
+  }
+  applyWizardView();
+`;
+}
+
 function generateAppJs(
   formModel: FormModel,
   wiring?: StaticGeneratorWiring & { fieldTypesJson: string },
 ): string {
   const fieldMapLines = buildFieldIdMapJs(formModel);
+  const wizardInstallJs = buildMultiWizardInstallJs(formModel);
+  const wizardSubmitGateJs =
+    formModel.layout.steps && formModel.layout.steps.length > 1
+      ? `
+    if (wizardStep < WIZARD_STEP_COUNT - 1) {
+      tryWizardNext();
+      return;
+    }
+`
+      : "";
 
   const submitBody = wiring
     ? buildVanillaWiredSubmitReplacement({
@@ -1040,11 +1227,11 @@ ${buildVanillaClientValidationSource()}
   var FIELD_ID_MAP = {
 ${fieldMapLines}
   };
-
+${wizardInstallJs}
   form.addEventListener("submit", async function (e) {
     e.preventDefault();
     syncRichTextEditors(form);
-    syncSignaturePads(form);
+    syncSignaturePads(form);${wizardSubmitGateJs}
 
     var errs = validateForm(form, FIELD_RULES);
     var errorKeys = Object.keys(errs);

--- a/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
+++ b/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
@@ -225,7 +225,12 @@ function collectAllFields(fields: FieldModel[]): FieldModel[] {
   return result;
 }
 
-function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, string>, ctx?: RepeaterCtx): string {
+function generateBootstrapField(
+  field: FieldModel,
+  domIdByKey: Map<string, string>,
+  ctx?: RepeaterCtx,
+  tableCell = false,
+): string {
   const { key, type, label, required, ui } = field;
   const nameAttr = ctx ? escapeHtml(indexedName(ctx.repeaterRoot, field, ctx.rowIdx)) : escapeHtml(key);
   const domId = domIdFor(field, domIdByKey, ctx);
@@ -240,6 +245,41 @@ function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, strin
     if (children.some((c) => c.type === "repeater")) {
       return `<div class="border rounded p-3 mb-4"><p class="text-muted small mb-0">Nested repeaters are not supported in this export.</p></div>`;
     }
+    const displayMode =
+      field.ui && typeof field.ui === "object" && (field.ui as Record<string, unknown>)["displayMode"] === "table"
+        ? "table"
+        : "cards";
+
+    if (displayMode === "table" && children.length > 0) {
+      const th = children
+        .map(
+          (c) =>
+            `<th scope="col">${escapeHtml(c.label)}${c.required ? ' <span class="text-danger" aria-hidden="true">*</span>' : ""}</th>`,
+        )
+        .join("");
+      const tdTemplate = children
+        .map((c) => `<td class="align-middle">${generateBootstrapField(c, domIdByKey, { repeaterRoot: field.key, rowIdx: 0 }, true)}</td>`)
+        .join("");
+      const rootEsc = escapeHtml(field.key);
+      return `<fieldset class="border rounded p-3 mb-4" data-fs-repeater="${rootEsc}">
+  <legend class="float-none w-auto px-2 fs-6 fw-semibold">${escapeHtml(label)}</legend>
+  <div class="table-responsive">
+    <table class="table table-bordered align-middle mb-0 fs-repeater-data-table">
+      <thead><tr>${th}<th scope="col" class="text-end" style="width:6rem">Actions</th></tr></thead>
+      <tbody class="repeater-rows">
+        <tr class="repeater-row table-light" data-row-index="0">
+          ${tdTemplate}
+          <td class="text-end align-middle">
+            <button type="button" class="btn btn-sm btn-outline-secondary fs-repeater-remove" style="display:none">Remove</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <button type="button" class="btn btn-sm btn-outline-primary fs-repeater-add">Add row</button>
+</fieldset>`;
+    }
+
     const inner = children
       .map((c) => generateBootstrapField(c, domIdByKey, { repeaterRoot: field.key, rowIdx: 0 }))
       .join("\n");
@@ -258,7 +298,7 @@ function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, strin
 
   if (type === "group") {
     const children = field.children || [];
-    const inner = children.map((c) => generateBootstrapField(c, domIdByKey, ctx)).join("\n");
+    const inner = children.map((c) => generateBootstrapField(c, domIdByKey, ctx, tableCell)).join("\n");
     return `<fieldset class="border rounded p-3 mb-4">
   <legend class="float-none w-auto px-2 fs-6 fw-semibold">${escapeHtml(label)}</legend>
   ${inner}
@@ -275,7 +315,12 @@ function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, strin
   switch (type) {
     case "textarea":
     case "richtext":
-      return wrapControl(label, required, domId, helpText, `<textarea
+      return wrapControl(
+        label,
+        required,
+        domId,
+        helpText,
+        `<textarea
           class="form-control"
           name="${nameAttr}"
           id="${domId}"
@@ -285,7 +330,9 @@ function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, strin
           ${ariaRequired}
           ${ariaDescribedBy}
           ${autoCompleteAttr}
-        ></textarea>`);
+        ></textarea>`,
+        tableCell,
+      );
     case "select": {
       const options = field.constraints?.enum || [];
       return wrapControl(
@@ -305,10 +352,13 @@ function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, strin
           <option value="">${escapeHtml(placeholder) || "Select..."}</option>
           ${options.map((o) => `<option value="${escapeHtml(o)}">${escapeHtml(o)}</option>`).join("\n")}
         </select>`,
+        tableCell,
       );
     }
-    case "checkbox":
-      return `<div class="form-check mb-3">
+    case "checkbox": {
+      const chkMb = tableCell ? "mb-1" : "mb-3";
+      const chkLbl = tableCell ? "form-check-label visually-hidden" : "form-check-label";
+      return `<div class="form-check ${chkMb}">
   <input
     class="form-check-input"
     type="checkbox"
@@ -318,12 +368,13 @@ function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, strin
     ${ariaRequired}
     ${ariaDescribedBy}
   />
-  <label class="form-check-label" for="${domId}">
+  <label class="${chkLbl}" for="${domId}">
     ${escapeHtml(label)}${required ? ' <span class="text-danger" aria-hidden="true">*</span>' : ""}
   </label>
-  ${helpText ? `<div id="${domId}-help" class="form-text">${escapeHtml(helpText)}</div>` : ""}
+  ${helpText && !tableCell ? `<div id="${domId}-help" class="form-text">${escapeHtml(helpText)}</div>` : ""}
   <div id="${domId}-error" class="invalid-feedback d-block" role="alert"></div>
 </div>`;
+    }
     case "file": {
       const xui = ui?.["x-ui"];
       const accept = xui?.accept ? `accept="${escapeHtml(String(xui.accept))}"` : "";
@@ -344,6 +395,7 @@ function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, strin
           ${ariaRequired}
           ${ariaDescribedBy}
         />`,
+        tableCell,
       );
     }
     case "signature": {
@@ -355,6 +407,7 @@ function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, strin
         helpText,
         `<canvas id="${domId}_canvas" width="400" height="160" class="border rounded bg-white mb-2" style="max-width:100%;touch-action:none" data-fs-sig-target="${escapeHtml(hidId)}"></canvas>
         <input type="hidden" name="${nameAttr}" id="${escapeHtml(hidId)}" />`,
+        tableCell,
       );
     }
     case "typeahead": {
@@ -378,6 +431,7 @@ function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, strin
           ${ariaDescribedBy}
         />
         <datalist id="${escapeHtml(dlId)}"></datalist>`,
+        tableCell,
       );
     }
     case "calculated": {
@@ -398,6 +452,7 @@ function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, strin
           ${ariaRequired}
           ${ariaDescribedBy}
         />`,
+        tableCell,
       );
     }
     case "number": {
@@ -424,6 +479,7 @@ function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, strin
           ${ariaDescribedBy}
           ${autoCompleteAttr}
         />`,
+        tableCell,
       );
     }
     case "text":
@@ -446,6 +502,7 @@ function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, strin
           ${ariaDescribedBy}
           ${autoCompleteAttr}
         />`,
+        tableCell,
       );
     case "unknown":
     default:
@@ -464,6 +521,7 @@ function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, strin
           ${ariaRequired}
           ${ariaDescribedBy}
         />`,
+        tableCell,
       );
   }
 }
@@ -474,13 +532,16 @@ function wrapControl(
   domId: string,
   helpText: string | undefined,
   control: string,
+  tableCell = false,
 ): string {
-  return `<div class="mb-3">
-  <label class="form-label" for="${domId}">
+  const labelClass = tableCell ? "form-label visually-hidden" : "form-label";
+  const wrapClass = tableCell ? "mb-1" : "mb-3";
+  return `<div class="${wrapClass}">
+  <label class="${labelClass}" for="${domId}">
     ${escapeHtml(label)}${required ? ' <span class="text-danger" aria-hidden="true">*</span>' : ""}
   </label>
   ${control}
-  ${helpText ? `<div id="${domId}-help" class="form-text">${escapeHtml(helpText)}</div>` : ""}
+  ${helpText && !tableCell ? `<div id="${domId}-help" class="form-text">${escapeHtml(helpText)}</div>` : ""}
   <div id="${domId}-error" class="invalid-feedback d-block" role="alert"></div>
 </div>`;
 }

--- a/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
+++ b/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
@@ -492,6 +492,7 @@ function generateBootstrapField(
     }
     case "calculated": {
       const formula = field["x-calc"] ?? "";
+      const calcRep = ctx ? ` data-fs-calc-repeater="${escapeHtml(ctx.repeaterRoot)}"` : "";
       return wrapControl(
         label,
         required,
@@ -503,7 +504,7 @@ function generateBootstrapField(
           name="${nameAttr}"
           id="${domId}"
           readonly
-          data-fs-calculated="${escapeHtml(formula)}"
+          data-fs-calculated="${escapeHtml(formula)}"${calcRep}
           value=""
           ${ariaRequired}
           ${ariaDescribedBy}
@@ -708,6 +709,21 @@ body {
 .form-select:disabled {
   background-color: color-mix(in srgb, var(--fs-input-bg) 88%, var(--fs-muted));
 }
+
+.richtext-editable.form-control {
+  min-height: 6rem;
+  overflow-y: auto;
+}
+.richtext-editable[contenteditable="true"]:empty:before {
+  content: attr(data-placeholder);
+  color: color-mix(in srgb, var(--fs-muted) 85%, transparent);
+  pointer-events: none;
+}
+canvas.form-control.signature-pad-canvas {
+  display: block;
+  min-height: 10rem;
+  cursor: crosshair;
+}
 `;
 }
 
@@ -753,13 +769,68 @@ const STATIC_RUNTIME_HELPERS = `
     return out;
   }
 
+  function scopedRepeaterValues(form, repeaterRoot, rowIdx) {
+    var flat = formValuesStringMap(form);
+    var prefix = repeaterRoot + '.' + rowIdx + '.';
+    var out = {};
+    Object.keys(flat).forEach(function (k) {
+      out[k] = flat[k];
+    });
+    Object.keys(flat).forEach(function (k) {
+      if (k.indexOf(prefix) === 0) {
+        out[k.slice(prefix.length)] = flat[k];
+      }
+    });
+    return out;
+  }
+
   function updateCalculatedFields(form) {
-    var vals = formValuesStringMap(form);
     form.querySelectorAll('input[data-fs-calculated]').forEach(function (el) {
-      var f = el.getAttribute('data-fs-calculated') || '';
-      var r = evaluateCalcExpression(f, vals);
+      var formula = el.getAttribute('data-fs-calculated') || '';
+      var rep = el.getAttribute('data-fs-calc-repeater');
+      var vals;
+      if (rep) {
+        var row = el.closest('tr.repeater-row, .repeater-row');
+        var ri = row ? parseInt(row.getAttribute('data-row-index') || '0', 10) : 0;
+        vals = scopedRepeaterValues(form, rep, ri);
+      } else {
+        vals = formValuesStringMap(form);
+      }
+      var r = evaluateCalcExpression(formula, vals);
       el.value = typeof r === 'number' && isFinite(r) ? String(r) : String(r);
     });
+  }
+
+  function syncRichTextEditors(form) {
+    form.querySelectorAll('input[type="hidden"][data-fs-richtext]').forEach(function (hid) {
+      var wrap = hid.closest('.richtext-wrap');
+      var ed = wrap && wrap.querySelector('.richtext-editable');
+      if (ed) hid.value = ed.innerHTML;
+    });
+  }
+
+  function wireRichTextToolbar(form) {
+    form.addEventListener('click', function (e) {
+      var t = e.target;
+      if (!t || !t.closest) return;
+      var btn = t.closest('.fs-richtext-cmd');
+      if (!btn || !form.contains(btn)) return;
+      e.preventDefault();
+      var cmd = btn.getAttribute('data-cmd');
+      var wrap = btn.closest('.richtext-wrap');
+      var ed = wrap && wrap.querySelector('.richtext-editable');
+      if (ed && cmd) {
+        ed.focus();
+        document.execCommand(cmd, false, undefined);
+      }
+    });
+    form.addEventListener('input', function (e) {
+      var t = e.target;
+      if (!t || !t.classList || !t.classList.contains('richtext-editable')) return;
+      var wrap = t.closest('.richtext-wrap');
+      var hid = wrap && wrap.querySelector('input[data-fs-richtext]');
+      if (hid) hid.value = t.innerHTML;
+    }, true);
   }
 
   function syncSignaturePads(form) {
@@ -845,6 +916,7 @@ const STATIC_RUNTIME_HELPERS = `
         setRepeaterRowIndex(clone, root, n);
         rowsC.appendChild(clone);
         wireSignatureDrawing(clone);
+        updateCalculatedFields(form);
         refreshRemoveButtons();
       });
 
@@ -957,6 +1029,7 @@ ${buildVanillaClientValidationSource()}
   var FIELD_RULES = ${fieldRulesJson};
 
   wireSignatureDrawing(form);
+  wireRichTextToolbar(form);
   initRepeaters(form);
   initTypeaheads(form);
   form.addEventListener("input", function () {
@@ -970,6 +1043,7 @@ ${fieldMapLines}
 
   form.addEventListener("submit", async function (e) {
     e.preventDefault();
+    syncRichTextEditors(form);
     syncSignaturePads(form);
 
     var errs = validateForm(form, FIELD_RULES);

--- a/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
+++ b/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
@@ -1060,6 +1060,7 @@ ${fieldMapLines}
             : errorKeys.length +
                 " errors found. " +
                 (firstMsg || "Please review the highlighted fields.");
+        statusEl.className = "alert alert-danger mb-3";
       }
       var focusEl = null;
       var els = form.elements;
@@ -1082,7 +1083,10 @@ ${fieldMapLines}
 
     clearInlineFieldErrors(form);
     var statusClear = document.getElementById("form-status");
-    if (statusClear) statusClear.textContent = "";
+    if (statusClear) {
+      statusClear.textContent = "";
+      statusClear.className = "mb-3";
+    }
 
 ${submitIndented}
   });
@@ -1141,7 +1145,7 @@ export function generateStaticBootstrapFiles(
 <body>
   <main class="container py-4">
     <div class="fs-page-inner mx-auto">
-      <div id="form-status" class="text-danger mb-3" role="status" aria-live="polite"></div>
+      <div id="form-status" class="mb-3" role="status" aria-live="polite"></div>
       <h1 class="h3 mb-2">${escapeHtml(title)}</h1>
       ${description ? `<p class="text-muted mb-4">${escapeHtml(description)}</p>` : ""}
       ${bodyInner}

--- a/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
+++ b/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
@@ -45,6 +45,157 @@ function escapeHtml(text: string): string {
   return text.replace(/[&<>"']/g, (m) => map[m]);
 }
 
+/** Mirrors react-generator: JSON for client-side FIELD_RULES. */
+function buildClientFieldRulesJson(formModel: FormModel): string {
+  type Rule = {
+    label: string;
+    type: string;
+    required: boolean;
+    min?: number;
+    max?: number;
+    minLength?: number;
+    maxLength?: number;
+    pattern?: string;
+  };
+  const rules: Record<string, Rule> = {};
+  const walk = (fields: FieldModel[]) => {
+    for (const f of fields) {
+      if (f.type === "group" || f.type === "repeater") {
+        if (f.children?.length) walk(f.children);
+      } else {
+        const r: Rule = {
+          label: f.label,
+          type: f.type,
+          required: f.required,
+        };
+        const c = f.constraints;
+        if (c?.min !== undefined) r.min = c.min;
+        if (c?.max !== undefined) r.max = c.max;
+        if (c?.minLength !== undefined) r.minLength = c.minLength;
+        if (c?.maxLength !== undefined) r.maxLength = c.maxLength;
+        if (c?.pattern !== undefined) r.pattern = c.pattern;
+        rules[f.key] = r;
+      }
+    }
+  };
+  walk(formModel.fields);
+  return JSON.stringify(rules);
+}
+
+/** Vanilla JS: templatePathFromIndexedPath + validateForm (parity with React export). */
+function buildVanillaClientValidationSource(): string {
+  return `
+  function templatePathFromIndexedPath(path) {
+    return path.split(".").filter(function (p) {
+      return !/^\\d+$/.test(p);
+    }).join(".");
+  }
+
+  function validateForm(form, rules) {
+    var errs = {};
+    var emailRe = /^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/;
+
+    function applyTextRules(rule, raw, path) {
+      var v = String(raw || "").trim();
+      if (rule.required && v === "") {
+        errs[path] = rule.label + " is required.";
+        return;
+      }
+      if (v === "") return;
+
+      if (rule.type === "number") {
+        var normalized = v.replace(/\\s/g, "");
+        if (/[eE]/.test(normalized)) {
+          errs[path] = rule.label + " must be a valid number.";
+          return;
+        }
+        if (!/^-?(?:\\d+\\.?\\d*|\\.\\d+)$/.test(normalized)) {
+          errs[path] = rule.label + " must be a valid number.";
+          return;
+        }
+        var num = Number(normalized);
+        if (isNaN(num)) {
+          errs[path] = rule.label + " must be a valid number.";
+          return;
+        }
+        var disallowNegative = rule.min !== undefined && rule.min >= 0;
+        if (disallowNegative && num < 0) {
+          errs[path] = rule.label + " cannot be negative.";
+          return;
+        }
+        if (rule.min !== undefined && num < rule.min) {
+          errs[path] = rule.label + " must be at least " + rule.min + ".";
+          return;
+        }
+        if (rule.max !== undefined && num > rule.max) {
+          errs[path] = rule.label + " must be at most " + rule.max + ".";
+          return;
+        }
+      } else if (rule.type === "email") {
+        if (!emailRe.test(v)) errs[path] = "Enter a valid email address.";
+      }
+
+      if (!errs[path] && rule.minLength !== undefined && v.length < rule.minLength) {
+        errs[path] = rule.label + " is too short.";
+      }
+      if (!errs[path] && rule.maxLength !== undefined && v.length > rule.maxLength) {
+        errs[path] = rule.label + " is too long.";
+      }
+      if (!errs[path] && rule.pattern) {
+        try {
+          var re = new RegExp(rule.pattern);
+          if (!re.test(v)) errs[path] = rule.label + " format is invalid.";
+        } catch (e) {}
+      }
+    }
+
+    var named = form.querySelectorAll("[name]");
+    for (var i = 0; i < named.length; i++) {
+      var el = named[i];
+      var nm = el.name;
+      if (!nm) continue;
+      var tk = templatePathFromIndexedPath(nm);
+      var rule = rules[tk];
+      if (!rule) continue;
+
+      var tag = el.tagName.toLowerCase();
+
+      if (tag === "input") {
+        var inp = el;
+        var ty = inp.type;
+        if (ty === "checkbox") {
+          if (rule.required && !inp.checked) errs[nm] = rule.label + " is required.";
+          continue;
+        }
+        if (ty === "file") {
+          if (rule.required && (!inp.files || inp.files.length === 0)) errs[nm] = rule.label + " is required.";
+          continue;
+        }
+        if (ty === "hidden") {
+          if (rule.required && !(inp.value || "").trim()) errs[nm] = rule.label + " is required.";
+          continue;
+        }
+        if (inp.readOnly && rule.type === "calculated") continue;
+        applyTextRules(rule, inp.value || "", nm);
+        continue;
+      }
+
+      if (tag === "select") {
+        var val = el.value;
+        if (rule.required && (val === "" || val == null)) errs[nm] = rule.label + " is required.";
+        continue;
+      }
+
+      if (tag === "textarea") {
+        applyTextRules(rule, el.value || "", nm);
+      }
+    }
+
+    return errs;
+  }
+`;
+}
+
 function relativeUnderRepeater(repeaterRoot: string, fieldKey: string): string {
   if (fieldKey.startsWith(repeaterRoot + ".")) return fieldKey.slice(repeaterRoot.length + 1);
   return fieldKey;
@@ -249,10 +400,35 @@ function generateBootstrapField(field: FieldModel, domIdByKey: Map<string, strin
         />`,
       );
     }
+    case "number": {
+      const c = field.constraints;
+      const minAttr = c?.min !== undefined ? `min="${escapeHtml(String(c.min))}"` : "";
+      const maxAttr = c?.max !== undefined ? `max="${escapeHtml(String(c.max))}"` : "";
+      return wrapControl(
+        label,
+        required,
+        domId,
+        helpText,
+        `<input
+          class="form-control"
+          type="number"
+          name="${nameAttr}"
+          id="${domId}"
+          inputmode="decimal"
+          step="any"
+          ${minAttr}
+          ${maxAttr}
+          ${placeholder ? `placeholder="${escapeHtml(placeholder)}"` : ""}
+          ${required ? "required" : ""}
+          ${ariaRequired}
+          ${ariaDescribedBy}
+          ${autoCompleteAttr}
+        />`,
+      );
+    }
     case "text":
     case "email":
     case "password":
-    case "number":
     case "date":
       return wrapControl(
         label,
@@ -338,17 +514,21 @@ function buildFormBody(formModel: FormModel, domIdByKey: Map<string, string>): s
   </div>
 </div>`;
     });
-    return `<form id="main-form" novalidate>
+    return `<div class="fs-form-panel rounded shadow-sm p-4 mb-4">
+<form id="main-form" novalidate>
   ${sections.join("\n")}
   <button type="submit" class="btn btn-primary"${btnStyle}>${escapeHtml(submitText)}</button>
-</form>`;
+</form>
+</div>`;
   }
 
   const fieldHtml = orderedFields.map((f) => generateBootstrapField(f, domIdByKey)).join("\n");
-  return `<form id="main-form" novalidate>
+  return `<div class="fs-form-panel rounded shadow-sm p-4 mb-4">
+<form id="main-form" novalidate>
   ${fieldHtml}
   <button type="submit" class="btn btn-primary"${btnStyle}>${escapeHtml(submitText)}</button>
-</form>`;
+</form>
+</div>`;
 }
 
 function generateThemeCss(formModel: FormModel): string {
@@ -359,6 +539,7 @@ function generateThemeCss(formModel: FormModel): string {
   --bs-body-bg: ${colors.background};
   --bs-body-color: ${colors.text};
   --bs-border-color: ${colors.border};
+  --fs-surface: ${colors.surface};
   --fs-form-radius: ${radius}px;
   --fs-font-family: ${typography.fontFamily};
   --fs-base-font-size: ${typography.baseFontSize}px;
@@ -369,6 +550,12 @@ body {
   font-size: var(--fs-base-font-size);
   background-color: var(--bs-body-bg);
   color: var(--bs-body-color);
+}
+
+.fs-form-panel {
+  background-color: var(--fs-surface);
+  border: 1px solid color-mix(in srgb, var(--bs-border-color) 65%, transparent);
+  border-radius: var(--fs-form-radius);
 }
 
 .form-control:focus {
@@ -560,6 +747,33 @@ const STATIC_RUNTIME_HELPERS = `
       });
     });
   }
+
+  function clearInlineFieldErrors(form) {
+    form.querySelectorAll(".is-invalid").forEach(function (el) {
+      el.classList.remove("is-invalid");
+    });
+    form.querySelectorAll(".invalid-feedback").forEach(function (node) {
+      node.textContent = "";
+    });
+  }
+
+  function applyInlineFieldErrors(form, errs) {
+    clearInlineFieldErrors(form);
+    Object.keys(errs).forEach(function (name) {
+      var found = null;
+      for (var i = 0; i < form.elements.length; i++) {
+        if (form.elements[i].name === name) {
+          found = form.elements[i];
+          break;
+        }
+      }
+      if (!found) return;
+      var wrap = found.closest && found.closest(".mb-3, .form-check");
+      var errNode = wrap ? wrap.querySelector(".invalid-feedback") : null;
+      if (found.classList) found.classList.add("is-invalid");
+      if (errNode) errNode.textContent = errs[name];
+    });
+  }
 `;
 
 function generateAppJs(
@@ -583,6 +797,8 @@ function generateAppJs(
     .map((line) => "    " + line)
     .join("\n");
 
+  const fieldRulesJson = buildClientFieldRulesJson(formModel);
+
   return `/**
  * Generated by FormSync static-frontend-generator — do not edit by hand.
  */
@@ -591,6 +807,8 @@ function generateAppJs(
   if (!form) return;
 
 ${STATIC_RUNTIME_HELPERS}
+${buildVanillaClientValidationSource()}
+  var FIELD_RULES = ${fieldRulesJson};
 
   wireSignatureDrawing(form);
   initRepeaters(form);
@@ -607,41 +825,47 @@ ${fieldMapLines}
   form.addEventListener("submit", async function (e) {
     e.preventDefault();
     syncSignaturePads(form);
-    var fd = new FormData(form);
-    var data = Object.fromEntries(fd.entries());
 
-    var errs = validate(data);
+    var errs = validateForm(form, FIELD_RULES);
     var errorKeys = Object.keys(errs);
     if (errorKeys.length > 0) {
+      applyInlineFieldErrors(form, errs);
       var statusEl = document.getElementById("form-status");
+      var firstKey = errorKeys[0];
+      var firstMsg = firstKey ? errs[firstKey] : "";
       if (statusEl) {
         statusEl.textContent =
           errorKeys.length === 1
-            ? "1 error found. Please review the highlighted field."
-            : errorKeys.length + " errors found. Please review the highlighted fields.";
+            ? firstMsg || "Please fix the highlighted field."
+            : errorKeys.length +
+                " errors found. " +
+                (firstMsg || "Please review the highlighted fields.");
       }
-      var firstKey = errorKeys[0];
-      var firstId = FIELD_ID_MAP[firstKey];
-      if (firstId) {
-        var el = document.getElementById(firstId);
-        if (el) {
-          el.focus();
-          el.scrollIntoView({ behavior: "smooth", block: "center" });
+      var focusEl = null;
+      var els = form.elements;
+      for (var fi = 0; fi < els.length; fi++) {
+        var fe = els[fi];
+        if (fe.name === firstKey) {
+          focusEl = fe;
+          break;
         }
+      }
+      var tk = firstKey ? templatePathFromIndexedPath(firstKey) : "";
+      var fallbackId = tk ? FIELD_ID_MAP[tk] : "";
+      var el = focusEl || (fallbackId ? document.getElementById(fallbackId) : null);
+      if (el && el.focus) {
+        el.focus();
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
       }
       return;
     }
 
+    clearInlineFieldErrors(form);
     var statusClear = document.getElementById("form-status");
     if (statusClear) statusClear.textContent = "";
 
 ${submitIndented}
   });
-
-  function validate(data) {
-    var errs = {};
-    return errs;
-  }
 })();
 `;
 }

--- a/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
+++ b/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
@@ -201,6 +201,33 @@ function relativeUnderRepeater(repeaterRoot: string, fieldKey: string): string {
   return fieldKey;
 }
 
+/** Inline styles for repeater fieldset / table from field.ui.styleOverrides. */
+function repeaterChromeStyleAttr(field: FieldModel): {
+  fieldset: string;
+  legend: string;
+  theadTr: string;
+  addBtn: string;
+} {
+  const o = field.ui?.styleOverrides as Record<string, string> | undefined;
+  const border = o?.borderColor ?? "#dee2e6";
+  const bg = o?.backgroundColor;
+  const lc = o?.labelColor;
+  const accent = o?.focusColor;
+  const fss = [`border:1px solid ${border}`, "border-radius:0.375rem", "padding:1rem"];
+  if (bg) fss.push(`background-color:${bg}`);
+  const fieldset = ` style="${fss.join(";")}"`;
+  const legend = lc ? ` style="color:${lc}"` : "";
+  const theadBg =
+    lc && bg
+      ? `color-mix(in srgb, ${lc} 12%, ${bg})`
+      : bg
+        ? `color-mix(in srgb, #64748b 8%, ${bg})`
+        : "#f8f9fa";
+  const theadTr = ` style="background:${theadBg}${lc ? `;color:${lc}` : ""}"`;
+  const addBtn = accent ? ` style="color:${accent};border-color:${accent}"` : "";
+  return { fieldset, legend, theadTr, addBtn };
+}
+
 /** Indexed name for repeater rows (matches React export). */
 function indexedName(repeaterRoot: string, field: FieldModel, rowIdx: number): string {
   const rel = relativeUnderRepeater(repeaterRoot, field.key);
@@ -245,12 +272,21 @@ function generateBootstrapField(
     if (children.some((c) => c.type === "repeater")) {
       return `<div class="border rounded p-3 mb-4"><p class="text-muted small mb-0">Nested repeaters are not supported in this export.</p></div>`;
     }
+    if (children.length === 0) {
+      const rc = repeaterChromeStyleAttr(field);
+      return `<fieldset class="mb-4"${rc.fieldset}>
+  <legend class="float-none w-auto px-2 fs-6 fw-semibold"${rc.legend}>${escapeHtml(label)}</legend>
+  <p class="text-muted small mb-2">Add child fields to this repeater in the FormSync builder, then re-export. Repeating tables expect one column per child field.</p>
+  <button type="button" class="btn btn-sm btn-outline-secondary" disabled title="Add child fields in the builder first">Add row</button>
+</fieldset>`;
+    }
     const displayMode =
       field.ui && typeof field.ui === "object" && (field.ui as Record<string, unknown>)["displayMode"] === "table"
         ? "table"
         : "cards";
 
     if (displayMode === "table" && children.length > 0) {
+      const rc = repeaterChromeStyleAttr(field);
       const th = children
         .map(
           (c) =>
@@ -261,11 +297,11 @@ function generateBootstrapField(
         .map((c) => `<td class="align-middle">${generateBootstrapField(c, domIdByKey, { repeaterRoot: field.key, rowIdx: 0 }, true)}</td>`)
         .join("");
       const rootEsc = escapeHtml(field.key);
-      return `<fieldset class="border rounded p-3 mb-4" data-fs-repeater="${rootEsc}">
-  <legend class="float-none w-auto px-2 fs-6 fw-semibold">${escapeHtml(label)}</legend>
+      return `<fieldset class="mb-4"${rc.fieldset} data-fs-repeater="${rootEsc}">
+  <legend class="float-none w-auto px-2 fs-6 fw-semibold"${rc.legend}>${escapeHtml(label)}</legend>
   <div class="table-responsive">
     <table class="table table-bordered align-middle mb-0 fs-repeater-data-table">
-      <thead class="table-light"><tr>${th}<th scope="col" class="text-end" style="width:6rem">Actions</th></tr></thead>
+      <thead><tr${rc.theadTr}>${th}<th scope="col" class="text-end" style="width:6rem">Actions</th></tr></thead>
       <tbody class="repeater-rows">
         <tr class="repeater-row table-light" data-row-index="0">
           ${tdTemplate}
@@ -276,23 +312,24 @@ function generateBootstrapField(
       </tbody>
     </table>
   </div>
-  <button type="button" class="btn btn-sm btn-outline-primary fs-repeater-add">Add row</button>
+  <button type="button" class="btn btn-sm btn-outline-primary fs-repeater-add"${rc.addBtn}>Add row</button>
 </fieldset>`;
     }
 
+    const rc = repeaterChromeStyleAttr(field);
     const inner = children
       .map((c) => generateBootstrapField(c, domIdByKey, { repeaterRoot: field.key, rowIdx: 0 }))
       .join("\n");
     const rootEsc = escapeHtml(field.key);
-    return `<fieldset class="border rounded p-3 mb-4" data-fs-repeater="${rootEsc}">
-  <legend class="float-none w-auto px-2 fs-6 fw-semibold">${escapeHtml(label)}</legend>
+    return `<fieldset class="mb-4"${rc.fieldset} data-fs-repeater="${rootEsc}">
+  <legend class="float-none w-auto px-2 fs-6 fw-semibold"${rc.legend}>${escapeHtml(label)}</legend>
   <div class="repeater-rows">
     <div class="repeater-row border rounded p-3 mb-2 bg-light" data-row-index="0">
       ${inner}
     </div>
   </div>
   <button type="button" class="btn btn-sm btn-outline-secondary me-2 fs-repeater-remove" style="display:none">Remove row</button>
-  <button type="button" class="btn btn-sm btn-outline-primary fs-repeater-add">Add row</button>
+  <button type="button" class="btn btn-sm btn-outline-primary fs-repeater-add"${rc.addBtn}>Add row</button>
 </fieldset>`;
   }
 
@@ -314,7 +351,6 @@ function generateBootstrapField(
 
   switch (type) {
     case "textarea":
-    case "richtext":
       return wrapControl(
         label,
         required,
@@ -333,6 +369,26 @@ function generateBootstrapField(
         ></textarea>`,
         tableCell,
       );
+    case "richtext": {
+      return wrapControl(
+        label,
+        required,
+        domId,
+        helpText,
+        `<div class="richtext-wrap w-100">
+  <div class="richtext-toolbar btn-group flex-wrap mb-1" role="toolbar" aria-label="Formatting">
+    <button type="button" class="btn btn-sm btn-outline-secondary fs-richtext-cmd" data-cmd="bold" title="Bold"><strong>B</strong></button>
+    <button type="button" class="btn btn-sm btn-outline-secondary fs-richtext-cmd" data-cmd="italic" title="Italic"><em>I</em></button>
+    <button type="button" class="btn btn-sm btn-outline-secondary fs-richtext-cmd" data-cmd="underline" title="Underline"><span style="text-decoration:underline">U</span></button>
+    <button type="button" class="btn btn-sm btn-outline-secondary fs-richtext-cmd" data-cmd="insertUnorderedList" title="List">•</button>
+    <button type="button" class="btn btn-sm btn-outline-secondary fs-richtext-cmd" data-cmd="insertOrderedList" title="Numbered">1.</button>
+  </div>
+  <div id="${domId}" class="form-control richtext-editable" contenteditable="true" ${placeholder ? `data-placeholder="${escapeHtml(placeholder)}"` : ""} ${ariaRequired} ${ariaDescribedBy}></div>
+  <input type="hidden" data-fs-richtext name="${nameAttr}" value="" />
+</div>`,
+        tableCell,
+      );
+    }
     case "select": {
       const options = field.constraints?.enum || [];
       return wrapControl(
@@ -405,7 +461,7 @@ function generateBootstrapField(
         required,
         domId,
         helpText,
-        `<canvas id="${domId}_canvas" width="400" height="160" class="border rounded bg-white mb-2" style="max-width:100%;touch-action:none" data-fs-sig-target="${escapeHtml(hidId)}"></canvas>
+        `<canvas id="${domId}_canvas" width="400" height="160" class="form-control signature-pad-canvas mb-2" style="max-width:100%;touch-action:none" data-fs-sig-target="${escapeHtml(hidId)}"></canvas>
         <input type="hidden" name="${nameAttr}" id="${escapeHtml(hidId)}" />`,
         tableCell,
       );

--- a/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
+++ b/formsync/services/static-frontend-generator/src/generators/static-bootstrap-generator.ts
@@ -265,7 +265,7 @@ function generateBootstrapField(
   <legend class="float-none w-auto px-2 fs-6 fw-semibold">${escapeHtml(label)}</legend>
   <div class="table-responsive">
     <table class="table table-bordered align-middle mb-0 fs-repeater-data-table">
-      <thead><tr>${th}<th scope="col" class="text-end" style="width:6rem">Actions</th></tr></thead>
+      <thead class="table-light"><tr>${th}<th scope="col" class="text-end" style="width:6rem">Actions</th></tr></thead>
       <tbody class="repeater-rows">
         <tr class="repeater-row table-light" data-row-index="0">
           ${tdTemplate}
@@ -594,6 +594,8 @@ function buildFormBody(formModel: FormModel, domIdByKey: Map<string, string>): s
 
 function generateThemeCss(formModel: FormModel): string {
   const { colors, typography, radius } = formModel.theme;
+  const inputBg = colors.inputBackground ?? "#ffffff";
+  const muted = colors.muted ?? "#6c757d";
   return `/* Theme derived from FormModel */
 :root {
   --bs-primary: ${colors.primary};
@@ -601,6 +603,8 @@ function generateThemeCss(formModel: FormModel): string {
   --bs-body-color: ${colors.text};
   --bs-border-color: ${colors.border};
   --fs-surface: ${colors.surface};
+  --fs-input-bg: ${inputBg};
+  --fs-muted: ${muted};
   --fs-form-radius: ${radius}px;
   --fs-font-family: ${typography.fontFamily};
   --fs-base-font-size: ${typography.baseFontSize}px;
@@ -613,15 +617,40 @@ body {
   color: var(--bs-body-color);
 }
 
+/* Readable column width (Bootstrap .container is still wide at lg/xl) */
+.fs-page-inner {
+  max-width: min(100%, 40rem);
+}
+
 .fs-form-panel {
   background-color: var(--fs-surface);
   border: 1px solid color-mix(in srgb, var(--bs-border-color) 65%, transparent);
   border-radius: var(--fs-form-radius);
 }
 
-.form-control:focus {
+/* BS5 defaults .form-control background to --bs-body-bg; use theme inputBackground so fields contrast with page + panel */
+.form-control,
+.form-select {
+  background-color: var(--fs-input-bg);
+  color: var(--bs-body-color);
+  border-color: var(--bs-border-color);
+}
+
+.form-control::placeholder {
+  color: color-mix(in srgb, var(--fs-muted) 85%, transparent);
+}
+
+.form-control:focus,
+.form-select:focus {
+  background-color: var(--fs-input-bg);
+  color: var(--bs-body-color);
   border-color: ${colors.primary};
   box-shadow: 0 0 0 0.2rem color-mix(in srgb, ${colors.primary} 25%, transparent);
+}
+
+.form-control:disabled,
+.form-select:disabled {
+  background-color: color-mix(in srgb, var(--fs-input-bg) 88%, var(--fs-muted));
 }
 `;
 }
@@ -981,10 +1010,12 @@ export function generateStaticBootstrapFiles(
 </head>
 <body>
   <main class="container py-4">
-    <div id="form-status" class="text-danger mb-3" role="status" aria-live="polite"></div>
-    <h1 class="h3 mb-2">${escapeHtml(title)}</h1>
-    ${description ? `<p class="text-muted mb-4">${escapeHtml(description)}</p>` : ""}
-    ${bodyInner}
+    <div class="fs-page-inner mx-auto">
+      <div id="form-status" class="text-danger mb-3" role="status" aria-live="polite"></div>
+      <h1 class="h3 mb-2">${escapeHtml(title)}</h1>
+      ${description ? `<p class="text-muted mb-4">${escapeHtml(description)}</p>` : ""}
+      ${bodyInner}
+    </div>
   </main>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
   <script src="js/app.js"></script>


### PR DESCRIPTION
This pull request introduces several improvements to the form builder UI, focusing on enhanced usability and customization. The main changes include adding drag-and-drop reordering for top-level fields in the left panel, improving accessibility and visual cues, and allowing users to configure repeater fields as data tables. Additionally, session-based frontend/backend stack preferences are now included when navigating to the generated code page.

**Field Reordering and Usability Enhancements:**

* Added drag-and-drop reordering for top-level fields in the "Layers" tab of the left panel using `@dnd-kit`, including a draggable grip handle and visual feedback. This ensures that the order in the builder matches the export and canvas order. (`formsync/frontend/src/builder/LeftPanel.tsx`) [[1]](diffhunk://#diff-1ed15c56dd7aca76b4b642b28824e3707d2ef69ecf7204e7c8a2832f6df0dac6L2-R44) [[2]](diffhunk://#diff-1ed15c56dd7aca76b4b642b28824e3707d2ef69ecf7204e7c8a2832f6df0dac6L95-R142) [[3]](diffhunk://#diff-1ed15c56dd7aca76b4b642b28824e3707d2ef69ecf7204e7c8a2832f6df0dac6L136-R288) [[4]](diffhunk://#diff-1ed15c56dd7aca76b4b642b28824e3707d2ef69ecf7204e7c8a2832f6df0dac6L196-R327) [[5]](diffhunk://#diff-1ed15c56dd7aca76b4b642b28824e3707d2ef69ecf7204e7c8a2832f6df0dac6L217-R364)
* Improved accessibility for palette and remove buttons by adding `type="button"` and `aria-label` attributes. (`formsync/frontend/src/builder/LeftPanel.tsx`) [[1]](diffhunk://#diff-1ed15c56dd7aca76b4b642b28824e3707d2ef69ecf7204e7c8a2832f6df0dac6R94-R97) [[2]](diffhunk://#diff-1ed15c56dd7aca76b4b642b28824e3707d2ef69ecf7204e7c8a2832f6df0dac6L115-R169)

**Repeater Field Customization:**

* Added a "Repeating table" option to the palette, allowing users to create repeater fields with a table layout. (`formsync/frontend/src/builder/LeftPanel.tsx`) [[1]](diffhunk://#diff-1ed15c56dd7aca76b4b642b28824e3707d2ef69ecf7204e7c8a2832f6df0dac6R71) [[2]](diffhunk://#diff-1ed15c56dd7aca76b4b642b28824e3707d2ef69ecf7204e7c8a2832f6df0dac6L196-R327)
* Introduced a UI control in the right panel for configuring repeater fields to use either "Stacked cards" or "Data table" layouts, with explanatory help text. (`formsync/frontend/src/builder/RightPanel.tsx`)

**Navigation and State Management Improvements:**

* When navigating to the generated code page, the app now includes both frontend and backend stack preferences from session storage in the URL and navigation state, ensuring generated code matches user preferences. (`formsync/frontend/src/builder/BuilderLayout.tsx`) [[1]](diffhunk://#diff-071fce9a3be6241f6dd2b24ce6c519ea7491040c72aab8c72e57da64cffb50bcL8-R48) [[2]](diffhunk://#diff-071fce9a3be6241f6dd2b24ce6c519ea7491040c72aab8c72e57da64cffb50bcL105-R147) [[3]](diffhunk://#diff-071fce9a3be6241f6dd2b24ce6c519ea7491040c72aab8c72e57da64cffb50bcL124-R175)

**Visual and Accessibility Tweaks:**

* Improved the wizard stepper UI by using a checkmark icon for completed steps and enhancing button accessibility. (`formsync/frontend/src/builder/Canvas.tsx`) [[1]](diffhunk://#diff-02c56063fc1c4174696ac0c38d5471a42b7092c2e677b1ae325dc547c38864c9L2-R2) [[2]](diffhunk://#diff-02c56063fc1c4174696ac0c38d5471a42b7092c2e677b1ae325dc547c38864c9R271-R295)
* Adjusted canvas and field rendering for better clarity and maintainability, including correct handling of repeater and checkbox labels. (`formsync/frontend/src/builder/Canvas.tsx`) [[1]](diffhunk://#diff-02c56063fc1c4174696ac0c38d5471a42b7092c2e677b1ae325dc547c38864c9L192-R193) [[2]](diffhunk://#diff-02c56063fc1c4174696ac0c38d5471a42b7092c2e677b1ae325dc547c38864c9L339-R358)

**Minor Updates:**

* Added the `FolderUp` icon import for file field previews. (`formsync/frontend/src/builder/plugins/FileFieldPreview.tsx`)